### PR TITLE
Upgrade C and C++ parts to EVMC 7.5.0

### DIFF
--- a/tests/evmc_c/evmc.h
+++ b/tests/evmc_c/evmc.h
@@ -28,7 +28,7 @@
 #include <stddef.h>  /* Definition of size_t. */
 #include <stdint.h>  /* Definition of int64_t, uint64_t. */
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -295,6 +295,9 @@ enum evmc_status_code
      */
     EVMC_WASM_TRAP = 16,
 
+    /** The caller does not have enough funds for value transfer. */
+    EVMC_INSUFFICIENT_BALANCE = 17,
+
     /** EVM implementation generic internal error. */
     EVMC_INTERNAL_ERROR = -1,
 
@@ -345,8 +348,8 @@ struct evmc_result
     /**
      * The amount of gas left after the execution.
      *
-     *  If evmc_result::code is not ::EVMC_SUCCESS nor ::EVMC_REVERT
-     *  the value MUST be 0.
+     * If evmc_result::status_code is neither ::EVMC_SUCCESS nor ::EVMC_REVERT
+     * the value MUST be 0.
      */
     int64_t gas_left;
 
@@ -914,7 +917,7 @@ struct evmc_vm
 
 /* END Python CFFI declarations */
 
-#if EVMC_DOCUMENTATION
+#ifdef EVMC_DOCUMENTATION
 /**
  * Example of a function creating an instance of an example EVM implementation.
  *
@@ -933,7 +936,7 @@ struct evmc_vm
 struct evmc_vm* evmc_create_example_vm(void);
 #endif
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/tests/evmc_c/example_host.cpp
+++ b/tests/evmc_c/example_host.cpp
@@ -173,7 +173,7 @@ const evmc_host_interface* example_host_get_interface()
     return &evmc::Host::get_interface();
 }
 
-evmc_host_context* example_host_create_context(evmc_tx_context tx_context)
+evmc_host_context* example_host_create_context(evmc_tx_context& tx_context)
 {
 #if 0
     auto host = new ExampleHost{tx_context};

--- a/tests/evmc_c/example_host.cpp
+++ b/tests/evmc_c/example_host.cpp
@@ -5,6 +5,9 @@
 
 /// @file
 /// Example implementation of an EVMC Host.
+
+#include "example_host.h"
+
 #include "evmc.hpp"
 
 #include <algorithm>
@@ -17,6 +20,8 @@ namespace evmc
 {
 struct account
 {
+    virtual ~account() = default;
+
     evmc::uint256be balance = {};
     std::vector<uint8_t> code;
     std::map<evmc::bytes32, evmc::bytes32> storage;
@@ -45,9 +50,10 @@ class ExampleHost : public evmc::Host
 
 public:
     ExampleHost() = default;
-    explicit ExampleHost(evmc_tx_context& _tx_context) noexcept : tx_context{_tx_context} {};
+    explicit ExampleHost(evmc_tx_context& _tx_context) noexcept : tx_context{_tx_context} {}
     ExampleHost(evmc_tx_context& _tx_context, evmc::accounts& _accounts) noexcept
-      : accounts{_accounts}, tx_context{_tx_context} {};
+      : accounts{_accounts}, tx_context{_tx_context}
+    {}
 
     bool account_exists(const evmc::address& addr) const noexcept final
     {
@@ -159,6 +165,7 @@ public:
     }
 };
 
+
 extern "C" {
 
 const evmc_host_interface* example_host_get_interface()
@@ -166,16 +173,21 @@ const evmc_host_interface* example_host_get_interface()
     return &evmc::Host::get_interface();
 }
 
-evmc_host_context* example_host_create_context(evmc_tx_context &tx_context)
+evmc_host_context* example_host_create_context(evmc_tx_context tx_context)
 {
+#if 0
+    auto host = new ExampleHost{tx_context};
+#else
+    // Added for `nim-evmc/tests/evmc_c`:
     evmc::accounts accounts;
     evmc::account acc;
     evmc_address addr = {{0, 1, 2}};
     acc.balance = {{1, 0}};
     acc.code = {10, 11, 12, 13, 14, 15};
     accounts[addr] = acc;
-
     auto host = new ExampleHost{tx_context, accounts};
+#endif
+
     return host->to_context();
 }
 

--- a/tests/evmc_c/example_host.h
+++ b/tests/evmc_c/example_host.h
@@ -1,0 +1,20 @@
+/* EVMC: Ethereum Client-VM Connector API.
+ * Copyright 2016-2019 The EVMC Authors.
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+#include "evmc.h"
+
+#if __cplusplus
+extern "C" {
+#endif
+
+const struct evmc_host_interface* example_host_get_interface();
+
+struct evmc_host_context* example_host_create_context(struct evmc_tx_context tx_context);
+
+void example_host_destroy_context(struct evmc_host_context* context);
+
+#if __cplusplus
+}
+#endif

--- a/tests/evmc_c/example_host.h
+++ b/tests/evmc_c/example_host.h
@@ -11,7 +11,7 @@ extern "C" {
 
 const struct evmc_host_interface* example_host_get_interface();
 
-struct evmc_host_context* example_host_create_context(struct evmc_tx_context tx_context);
+struct evmc_host_context* example_host_create_context(struct evmc_tx_context& tx_context);
 
 void example_host_destroy_context(struct evmc_host_context* context);
 

--- a/tests/evmc_c/example_vm.cpp
+++ b/tests/evmc_c/example_vm.cpp
@@ -1,60 +1,65 @@
-/* EVMC: Ethereum Client-VM Connector API.
- * Copyright 2016-2019 The EVMC Authors.
- * Licensed under the Apache License, Version 2.0.
- */
+// EVMC: Ethereum Client-VM Connector API.
+// Copyright 2016-2020 The EVMC Authors.
+// Licensed under the Apache License, Version 2.0.
 
 /// @file
 /// Example implementation of the EVMC VM interface.
 ///
-/// This VM does not do anything useful except for showing
-/// how EVMC VM API should be implemented.
-/// The implementation is done in C only, but could be done in C++ in very
-/// similar way.
+/// This VM implements a subset of EVM instructions in simplistic, incorrect and unsafe way:
+/// - memory bounds are not checked,
+/// - stack bounds are not checked,
+/// - most of the operations are done with 32-bit precision (instead of EVM 256-bit precision).
+/// Yet, it is capable of coping with some example EVM bytecode inputs, which is very useful
+/// in integration testing. The implementation is done in simple C++ for readability and uses
+/// pure C API and some C helpers.
 
+#include "example_vm.h"
 #include "evmc.h"
-#include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include "helpers.h"
+#include "instructions.h"
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
-extern "C" {
-  
-/// The example VM instance struct extending the evmc_vm.
-struct example_vm
+/// The Example VM methods, helper and types are contained in the anonymous namespace.
+/// Technically, this limits the visibility of these elements (internal linkage).
+/// This is not strictly required, but is good practice and promotes position independent code.
+namespace
 {
-    struct evmc_vm instance;  ///< The base struct.
-    int verbose;              ///< The verbosity level.
+/// The example VM instance struct extending the evmc_vm.
+struct ExampleVM : evmc_vm
+{
+    int verbose = 0;  ///< The verbosity level.
+    ExampleVM();      ///< Constructor to initialize the evmc_vm struct.
 };
 
 /// The implementation of the evmc_vm::destroy() method.
-static void destroy(struct evmc_vm* vm)
+void destroy(evmc_vm* instance)
 {
-    free(vm);
+    delete static_cast<ExampleVM*>(instance);
 }
 
 /// The example implementation of the evmc_vm::get_capabilities() method.
-static evmc_capabilities_flagset get_capabilities(struct evmc_vm* vm)
+evmc_capabilities_flagset get_capabilities(evmc_vm* /*instance*/)
 {
-    (void)vm;
-    return EVMC_CAPABILITY_EVM1 | EVMC_CAPABILITY_EWASM;
+    return EVMC_CAPABILITY_EVM1;
 }
 
 /// Example VM options.
 ///
 /// The implementation of the evmc_vm::set_option() method.
 /// VMs are allowed to omit this method implementation.
-static enum evmc_set_option_result set_option(struct evmc_vm* instance,
-                                              const char* name,
-                                              const char* value)
+enum evmc_set_option_result set_option(evmc_vm* instance, const char* name, const char* value)
 {
-    struct example_vm* vm = (struct example_vm*)instance;
-    if (strcmp(name, "verbose") == 0)
+    ExampleVM* vm = static_cast<ExampleVM*>(instance);
+    if (std::strcmp(name, "verbose") == 0)
     {
-        if (!value)
+        if (value == nullptr)
             return EVMC_SET_OPTION_INVALID_VALUE;
 
-        char* end = NULL;
-        long int v = strtol(value, &end, 0);
+        char* end = nullptr;
+        long int v = std::strtol(value, &end, 0);
         if (end == value)  // Parsing the value failed.
             return EVMC_SET_OPTION_INVALID_VALUE;
         if (v > 9 || v < -1)  // Not in the valid range.
@@ -66,147 +71,310 @@ static enum evmc_set_option_result set_option(struct evmc_vm* instance,
     return EVMC_SET_OPTION_INVALID_NAME;
 }
 
-/// The implementation of the evmc_result::release() method that frees
-/// the output buffer attached to the result object.
-static void free_result_output_data(const struct evmc_result* result)
+/// The Example VM stack representation.
+struct Stack
 {
-    free((uint8_t*)result->output_data);
+    evmc_uint256be items[1024];       ///< The array of stack items, uninitialized.
+    evmc_uint256be* pointer = items;  ///< The pointer to the currently first empty stack slot.
+
+    /// Pops an item from the top of the stack.
+    evmc_uint256be pop() { return *--pointer; }
+
+    /// Pushes an item to the top of the stack.
+    void push(evmc_uint256be value) { *pointer++ = value; }
+};
+
+/// The Example VM memory representation.
+struct Memory
+{
+    uint32_t size = 0;        ///< The current size of the memory.
+    uint8_t data[1024] = {};  ///< The fixed-size memory buffer.
+
+    /// Expands the "active" EVM memory by the given memory region defined by
+    /// @p offset and @p region_size. The region of size 0 also expands the memory
+    /// (what is different behavior than EVM specifies).
+    /// Returns pointer to the beginning of the region in the memory,
+    /// or nullptr if the memory cannot be expanded to the required size.
+    uint8_t* expand(uint32_t offset, uint32_t region_size)
+    {
+        uint32_t new_size = offset + region_size;
+        if (new_size > sizeof(data))
+            return nullptr;  // Cannot expand more than fixed max memory size.
+
+        if (new_size > size)
+            size = new_size;  // Update current memory size.
+
+        return &data[offset];
+    }
+
+    /// Stores the given value bytes in the memory at the given offset.
+    /// The Memory::size is updated accordingly.
+    /// Returns true if successful, false if the memory cannot be expanded to the required size.
+    bool store(uint32_t offset, const uint8_t* value_data, uint32_t value_size)
+    {
+        uint8_t* p = expand(offset, value_size);
+        if (p == nullptr)
+            return false;
+
+        std::memcpy(p, value_data, value_size);
+        return true;
+    }
+};
+
+/// Creates 256-bit value out of 32-bit input.
+inline evmc_uint256be to_uint256(uint32_t x)
+{
+    evmc_uint256be value = {};
+    value.bytes[31] = static_cast<uint8_t>(x);
+    value.bytes[30] = static_cast<uint8_t>(x >> 8);
+    value.bytes[29] = static_cast<uint8_t>(x >> 16);
+    value.bytes[28] = static_cast<uint8_t>(x >> 24);
+    return value;
 }
+
+/// Creates 256-bit value out of an 160-bit address.
+inline evmc_uint256be to_uint256(evmc_address address)
+{
+    evmc_uint256be value = {};
+    size_t offset = sizeof(value) - sizeof(address);
+    std::memcpy(&value.bytes[offset], address.bytes, sizeof(address.bytes));
+    return value;
+}
+
+/// Truncates 256-bit value to 32-bit value.
+inline uint32_t to_uint32(evmc_uint256be value)
+{
+    return (uint32_t{value.bytes[28]} << 24) | (uint32_t{value.bytes[29]} << 16) |
+           (uint32_t{value.bytes[30]} << 8) | (uint32_t{value.bytes[31]});
+}
+
+/// Truncates 256-bit value to 160-bit address.
+inline evmc_address to_address(evmc_uint256be value)
+{
+    evmc_address address = {};
+    size_t offset = sizeof(value) - sizeof(address);
+    std::memcpy(address.bytes, &value.bytes[offset], sizeof(address.bytes));
+    return address;
+}
+
 
 /// The example implementation of the evmc_vm::execute() method.
-static struct evmc_result execute(struct evmc_vm* instance,
-                                  const struct evmc_host_interface* host,
-                                  struct evmc_host_context* context,
-                                  enum evmc_revision rev,
-                                  const struct evmc_message* msg,
-                                  const uint8_t* code,
-                                  size_t code_size)
+evmc_result execute(evmc_vm* instance,
+                    const evmc_host_interface* host,
+                    evmc_host_context* context,
+                    enum evmc_revision rev,
+                    const evmc_message* msg,
+                    const uint8_t* code,
+                    size_t code_size)
 {
-    struct evmc_result ret = {.status_code = EVMC_INTERNAL_ERROR};
-    if (code_size == 0)
+    ExampleVM* vm = static_cast<ExampleVM*>(instance);
+
+    if (vm->verbose > 0)
+        std::puts("execution started\n");
+
+    int64_t gas_left = msg->gas;
+    Stack stack;
+    Memory memory;
+
+    for (size_t pc = 0; pc < code_size; ++pc)
     {
-        // In case of empty code return a fancy error message.
-        const char* error = rev == EVMC_BYZANTIUM ? "Welcome to Byzantium!" : "Hello Ethereum!";
-        ret.output_data = (const uint8_t*)error;
-        ret.output_size = strlen(error);
-        ret.status_code = EVMC_FAILURE;
-        ret.gas_left = msg->gas / 10;
-        ret.release = NULL;  // We don't need to release the constant messages.
-        return ret;
-    }
+        // Check remaining gas, assume each instruction costs 1.
+        gas_left -= 1;
+        if (gas_left < 0)
+            return evmc_make_result(EVMC_OUT_OF_GAS, 0, nullptr, 0);
 
-    struct example_vm* vm = (struct example_vm*)instance;
-
-    // Simulate executing by checking for some code patterns.
-    // Solidity inline assembly is used in the examples instead of EVM bytecode.
-
-    // Assembly: `{ mstore(0, address()) return(0, msize()) }`.
-    const char return_address[] = "\x30\x60\x00\x52\x59\x60\x00\xf3";
-
-    // Assembly: `{ sstore(0, add(sload(0), 1)) }`
-    const char counter[] = "\x60\x01\x60\x00\x54\x01\x60\x00\x55";
-
-    // Assembly: `{ mstore(0, number()) return(0, msize()) }`
-    const char return_block_number[] = "\x43\x60\x00\x52\x59\x60\x00\xf3";
-
-    // Assembly: `{ sstore(0, number()) mstore(0, number()) return(0, msize()) }`
-    const char save_return_block_number[] = "\x43\x60\x00\x55\x43\x60\x00\x52\x59\x60\x00\xf3";
-
-    // Assembly: PUSH(0) 6x DUP1 CALL
-    const char make_a_call[] = "\x60\x00\x80\x80\x80\x80\x80\x80\xf1";
-
-    if (msg->kind == EVMC_CREATE)
-    {
-        ret.status_code = EVMC_SUCCESS;
-        ret.gas_left = msg->gas / 10;
-        return ret;
-    }
-    else if (code_size == (sizeof(return_address) - 1) &&
-             strncmp((const char*)code, return_address, code_size) == 0)
-    {
-        static const size_t address_size = sizeof(msg->destination);
-        uint8_t* output_data = (uint8_t*)malloc(address_size);
-        if (!output_data)
+        switch (code[pc])
         {
-            // malloc failed, report internal error.
-            ret.status_code = EVMC_INTERNAL_ERROR;
-            return ret;
+        default:
+            return evmc_make_result(EVMC_UNDEFINED_INSTRUCTION, 0, nullptr, 0);
+
+        case OP_STOP:
+            return evmc_make_result(EVMC_SUCCESS, gas_left, nullptr, 0);
+
+        case OP_ADD:
+        {
+            uint32_t a = to_uint32(stack.pop());
+            uint32_t b = to_uint32(stack.pop());
+            uint32_t sum = a + b;
+            stack.push(to_uint256(sum));
+            break;
         }
-        memcpy(output_data, &msg->destination, address_size);
-        ret.status_code = EVMC_SUCCESS;
-        ret.output_data = output_data;
-        ret.output_size = address_size;
-        ret.release = &free_result_output_data;
-        return ret;
+
+        case OP_ADDRESS:
+        {
+            evmc_uint256be value = to_uint256(msg->destination);
+            stack.push(value);
+            break;
+        }
+
+        case OP_CALLDATALOAD:
+        {
+            uint32_t offset = to_uint32(stack.pop());
+            evmc_uint256be value = {};
+
+            if (offset < msg->input_size)
+            {
+                size_t copy_size = std::min(msg->input_size - offset, sizeof(value));
+                std::memcpy(value.bytes, &msg->input_data[offset], copy_size);
+            }
+
+            stack.push(value);
+            break;
+        }
+
+        case OP_NUMBER:
+        {
+            evmc_uint256be value =
+                to_uint256(static_cast<uint32_t>(host->get_tx_context(context).block_number));
+            stack.push(value);
+            break;
+        }
+
+        case OP_MSTORE:
+        {
+            uint32_t index = to_uint32(stack.pop());
+            evmc_uint256be value = stack.pop();
+            if (!memory.store(index, value.bytes, sizeof(value)))
+                return evmc_make_result(EVMC_FAILURE, 0, nullptr, 0);
+            break;
+        }
+
+        case OP_SLOAD:
+        {
+            evmc_uint256be index = stack.pop();
+            evmc_uint256be value = host->get_storage(context, &msg->destination, &index);
+            stack.push(value);
+            break;
+        }
+
+        case OP_SSTORE:
+        {
+            evmc_uint256be index = stack.pop();
+            evmc_uint256be value = stack.pop();
+            host->set_storage(context, &msg->destination, &index, &value);
+            break;
+        }
+
+        case OP_MSIZE:
+        {
+            evmc_uint256be value = to_uint256(memory.size);
+            stack.push(value);
+            break;
+        }
+
+        case OP_PUSH1:
+        case OP_PUSH2:
+        case OP_PUSH3:
+        case OP_PUSH4:
+        case OP_PUSH5:
+        case OP_PUSH6:
+        case OP_PUSH7:
+        case OP_PUSH8:
+        case OP_PUSH9:
+        case OP_PUSH10:
+        case OP_PUSH11:
+        case OP_PUSH12:
+        case OP_PUSH13:
+        case OP_PUSH14:
+        case OP_PUSH15:
+        case OP_PUSH16:
+        case OP_PUSH17:
+        case OP_PUSH18:
+        case OP_PUSH19:
+        case OP_PUSH20:
+        case OP_PUSH21:
+        case OP_PUSH22:
+        case OP_PUSH23:
+        case OP_PUSH24:
+        case OP_PUSH25:
+        case OP_PUSH26:
+        case OP_PUSH27:
+        case OP_PUSH28:
+        case OP_PUSH29:
+        case OP_PUSH30:
+        case OP_PUSH31:
+        case OP_PUSH32:
+        {
+            evmc_uint256be value = {};
+            size_t num_push_bytes = size_t{code[pc]} - OP_PUSH1 + 1;
+            size_t offset = sizeof(value) - num_push_bytes;
+            std::memcpy(&value.bytes[offset], &code[pc + 1], num_push_bytes);
+            pc += num_push_bytes;
+            stack.push(value);
+            break;
+        }
+
+        case OP_DUP1:
+        {
+            evmc_uint256be value = stack.pop();
+            stack.push(value);
+            stack.push(value);
+            break;
+        }
+
+        case OP_CALL:
+        {
+            evmc_message call_msg = {};
+            call_msg.gas = to_uint32(stack.pop());
+            call_msg.destination = to_address(stack.pop());
+            call_msg.value = stack.pop();
+
+            uint32_t call_input_offset = to_uint32(stack.pop());
+            uint32_t call_input_size = to_uint32(stack.pop());
+            call_msg.input_data = memory.expand(call_input_offset, call_input_size);
+            call_msg.input_size = call_input_size;
+
+            uint32_t call_output_offset = to_uint32(stack.pop());
+            uint32_t call_output_size = to_uint32(stack.pop());
+            uint8_t* call_output_ptr = memory.expand(call_output_offset, call_output_size);
+
+            if (call_msg.input_data == nullptr || call_output_ptr == nullptr)
+                return evmc_make_result(EVMC_FAILURE, 0, nullptr, 0);
+
+            evmc_result call_result = host->call(context, &call_msg);
+
+            evmc_uint256be value = to_uint256(call_result.status_code == EVMC_SUCCESS);
+            stack.push(value);
+
+            if (call_output_size > call_result.output_size)
+                call_output_size = static_cast<uint32_t>(call_result.output_size);
+            memory.store(call_output_offset, call_result.output_data, call_output_size);
+
+            if (call_result.release != nullptr)
+                call_result.release(&call_result);
+            break;
+        }
+
+        case OP_RETURN:
+        {
+            uint32_t output_offset = to_uint32(stack.pop());
+            uint32_t output_size = to_uint32(stack.pop());
+            uint8_t* output_ptr = memory.expand(output_offset, output_size);
+            if (output_ptr == nullptr)
+                return evmc_make_result(EVMC_FAILURE, 0, nullptr, 0);
+
+            return evmc_make_result(EVMC_SUCCESS, gas_left, output_ptr, output_size);
+        }
+
+        case OP_REVERT:
+        {
+            if (rev < EVMC_BYZANTIUM)
+                return evmc_make_result(EVMC_UNDEFINED_INSTRUCTION, 0, nullptr, 0);
+
+            uint32_t output_offset = to_uint32(stack.pop());
+            uint32_t output_size = to_uint32(stack.pop());
+            uint8_t* output_ptr = memory.expand(output_offset, output_size);
+            if (output_ptr == nullptr)
+                return evmc_make_result(EVMC_FAILURE, 0, nullptr, 0);
+
+            return evmc_make_result(EVMC_REVERT, gas_left, output_ptr, output_size);
+        }
+        }
     }
-    else if (code_size == (sizeof(counter) - 1) &&
-             strncmp((const char*)code, counter, code_size) == 0)
-    {
-        const evmc_bytes32 key = {{0}};
-        evmc_bytes32 value = host->get_storage(context, &msg->destination, &key);
-        value.bytes[31]++;
-        host->set_storage(context, &msg->destination, &key, &value);
-        ret.status_code = EVMC_SUCCESS;
-        return ret;
-    }
-    else if (code_size == (sizeof(return_block_number) - 1) &&
-             strncmp((const char*)code, return_block_number, code_size) == 0)
-    {
-        const struct evmc_tx_context tx_context = host->get_tx_context(context);
-        const size_t output_size = 20;
 
-        uint8_t* output_data = (uint8_t*)calloc(1, output_size);
-        snprintf((char*)output_data, output_size, "%u", (unsigned)tx_context.block_number);
-        ret.status_code = EVMC_SUCCESS;
-        ret.gas_left = msg->gas / 2;
-        ret.output_data = output_data;
-        ret.output_size = output_size;
-        ret.release = &free_result_output_data;
-        return ret;
-    }
-    else if (code_size == (sizeof(save_return_block_number) - 1) &&
-             strncmp((const char*)code, save_return_block_number, code_size) == 0)
-    {
-        const struct evmc_tx_context tx_context = host->get_tx_context(context);
-        const size_t output_size = 20;
-
-        // Store block number.
-        const evmc_bytes32 key = {{0}};
-        evmc_bytes32 value = {{0}};
-        // NOTE: assume block number is <= 255
-        value.bytes[31] = (uint8_t)tx_context.block_number;
-        host->set_storage(context, &msg->destination, &key, &value);
-
-        // Return block number.
-        uint8_t* output_data = (uint8_t*)calloc(1, output_size);
-        snprintf((char*)output_data, output_size, "%u", (unsigned)tx_context.block_number);
-        ret.status_code = EVMC_SUCCESS;
-        ret.gas_left = msg->gas / 2;
-        ret.output_data = output_data;
-        ret.output_size = output_size;
-        ret.release = &free_result_output_data;
-        return ret;
-    }
-    else if (code_size == (sizeof(make_a_call) - 1) &&
-             strncmp((const char*)code, make_a_call, code_size) == 0)
-    {
-        struct evmc_message call_msg;
-        memset(&call_msg, 0, sizeof(call_msg));
-        call_msg.kind = EVMC_CALL;
-        call_msg.depth = msg->depth + 1;
-        call_msg.gas = msg->gas - (msg->gas / 64);
-        call_msg.sender = msg->destination;
-        return host->call(context, &call_msg);
-    }
-
-    ret.status_code = EVMC_FAILURE;
-    ret.gas_left = 0;
-
-    if (vm->verbose)
-        printf("Execution done.\n");
-
-    return ret;
+    return evmc_make_result(EVMC_SUCCESS, gas_left, nullptr, 0);
 }
+
 
 /// @cond internal
 #if !defined(PROJECT_VERSION)
@@ -215,21 +383,13 @@ static struct evmc_result execute(struct evmc_vm* instance,
 #endif
 /// @endcond
 
-struct evmc_vm* evmc_create_example_vm()
-{
-    struct evmc_vm init = {
-        .abi_version = EVMC_ABI_VERSION,
-        .name = "example_vm",
-        .version = PROJECT_VERSION,
-        .destroy = destroy,
-        .execute = execute,
-        .get_capabilities = get_capabilities,
-        .set_option = set_option,
-    };
-    struct example_vm* vm = (example_vm*)calloc(1, sizeof(struct example_vm));
-    struct evmc_vm* interface = &vm->instance;
-    memcpy(interface, &init, sizeof(init));
-    return interface;
-}
+ExampleVM::ExampleVM()
+  : evmc_vm{EVMC_ABI_VERSION, "example_vm",       PROJECT_VERSION, ::destroy,
+            ::execute,        ::get_capabilities, ::set_option}
+{}
+}  // namespace
 
+extern "C" evmc_vm* evmc_create_example_vm()
+{
+    return new ExampleVM;
 }

--- a/tests/evmc_c/example_vm.h
+++ b/tests/evmc_c/example_vm.h
@@ -1,0 +1,22 @@
+/* EVMC: Ethereum Client-VM Connector API.
+ * Copyright 2018-2019 The EVMC Authors.
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+#pragma once
+
+#include "evmc.h"
+#include "utils.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Creates EVMC Example VM.
+ */
+EVMC_EXPORT struct evmc_vm* evmc_create_example_vm(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/evmc_c/instructions.h
+++ b/tests/evmc_c/instructions.h
@@ -1,0 +1,226 @@
+/* EVMC: Ethereum Client-VM Connector API.
+ * Copyright 2018-2019 The EVMC Authors.
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+/**
+ * EVM Instruction Tables
+ *
+ * A collection of metrics for EVM1 instruction set.
+ *
+ * @defgroup instructions EVM Instructions
+ * @{
+ */
+#pragma once
+
+#include "evmc.h"
+#include "utils.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * The list of EVM 1 opcodes from every EVM revision.
+ */
+enum evmc_opcode
+{
+    OP_STOP = 0x00,
+    OP_ADD = 0x01,
+    OP_MUL = 0x02,
+    OP_SUB = 0x03,
+    OP_DIV = 0x04,
+    OP_SDIV = 0x05,
+    OP_MOD = 0x06,
+    OP_SMOD = 0x07,
+    OP_ADDMOD = 0x08,
+    OP_MULMOD = 0x09,
+    OP_EXP = 0x0a,
+    OP_SIGNEXTEND = 0x0b,
+
+    OP_LT = 0x10,
+    OP_GT = 0x11,
+    OP_SLT = 0x12,
+    OP_SGT = 0x13,
+    OP_EQ = 0x14,
+    OP_ISZERO = 0x15,
+    OP_AND = 0x16,
+    OP_OR = 0x17,
+    OP_XOR = 0x18,
+    OP_NOT = 0x19,
+    OP_BYTE = 0x1a,
+    OP_SHL = 0x1b,
+    OP_SHR = 0x1c,
+    OP_SAR = 0x1d,
+
+    OP_SHA3 = 0x20,
+
+    OP_ADDRESS = 0x30,
+    OP_BALANCE = 0x31,
+    OP_ORIGIN = 0x32,
+    OP_CALLER = 0x33,
+    OP_CALLVALUE = 0x34,
+    OP_CALLDATALOAD = 0x35,
+    OP_CALLDATASIZE = 0x36,
+    OP_CALLDATACOPY = 0x37,
+    OP_CODESIZE = 0x38,
+    OP_CODECOPY = 0x39,
+    OP_GASPRICE = 0x3a,
+    OP_EXTCODESIZE = 0x3b,
+    OP_EXTCODECOPY = 0x3c,
+    OP_RETURNDATASIZE = 0x3d,
+    OP_RETURNDATACOPY = 0x3e,
+    OP_EXTCODEHASH = 0x3f,
+
+    OP_BLOCKHASH = 0x40,
+    OP_COINBASE = 0x41,
+    OP_TIMESTAMP = 0x42,
+    OP_NUMBER = 0x43,
+    OP_DIFFICULTY = 0x44,
+    OP_GASLIMIT = 0x45,
+    OP_CHAINID = 0x46,
+    OP_SELFBALANCE = 0x47,
+
+    OP_POP = 0x50,
+    OP_MLOAD = 0x51,
+    OP_MSTORE = 0x52,
+    OP_MSTORE8 = 0x53,
+    OP_SLOAD = 0x54,
+    OP_SSTORE = 0x55,
+    OP_JUMP = 0x56,
+    OP_JUMPI = 0x57,
+    OP_PC = 0x58,
+    OP_MSIZE = 0x59,
+    OP_GAS = 0x5a,
+    OP_JUMPDEST = 0x5b,
+
+    OP_PUSH1 = 0x60,
+    OP_PUSH2 = 0x61,
+    OP_PUSH3 = 0x62,
+    OP_PUSH4 = 0x63,
+    OP_PUSH5 = 0x64,
+    OP_PUSH6 = 0x65,
+    OP_PUSH7 = 0x66,
+    OP_PUSH8 = 0x67,
+    OP_PUSH9 = 0x68,
+    OP_PUSH10 = 0x69,
+    OP_PUSH11 = 0x6a,
+    OP_PUSH12 = 0x6b,
+    OP_PUSH13 = 0x6c,
+    OP_PUSH14 = 0x6d,
+    OP_PUSH15 = 0x6e,
+    OP_PUSH16 = 0x6f,
+    OP_PUSH17 = 0x70,
+    OP_PUSH18 = 0x71,
+    OP_PUSH19 = 0x72,
+    OP_PUSH20 = 0x73,
+    OP_PUSH21 = 0x74,
+    OP_PUSH22 = 0x75,
+    OP_PUSH23 = 0x76,
+    OP_PUSH24 = 0x77,
+    OP_PUSH25 = 0x78,
+    OP_PUSH26 = 0x79,
+    OP_PUSH27 = 0x7a,
+    OP_PUSH28 = 0x7b,
+    OP_PUSH29 = 0x7c,
+    OP_PUSH30 = 0x7d,
+    OP_PUSH31 = 0x7e,
+    OP_PUSH32 = 0x7f,
+    OP_DUP1 = 0x80,
+    OP_DUP2 = 0x81,
+    OP_DUP3 = 0x82,
+    OP_DUP4 = 0x83,
+    OP_DUP5 = 0x84,
+    OP_DUP6 = 0x85,
+    OP_DUP7 = 0x86,
+    OP_DUP8 = 0x87,
+    OP_DUP9 = 0x88,
+    OP_DUP10 = 0x89,
+    OP_DUP11 = 0x8a,
+    OP_DUP12 = 0x8b,
+    OP_DUP13 = 0x8c,
+    OP_DUP14 = 0x8d,
+    OP_DUP15 = 0x8e,
+    OP_DUP16 = 0x8f,
+    OP_SWAP1 = 0x90,
+    OP_SWAP2 = 0x91,
+    OP_SWAP3 = 0x92,
+    OP_SWAP4 = 0x93,
+    OP_SWAP5 = 0x94,
+    OP_SWAP6 = 0x95,
+    OP_SWAP7 = 0x96,
+    OP_SWAP8 = 0x97,
+    OP_SWAP9 = 0x98,
+    OP_SWAP10 = 0x99,
+    OP_SWAP11 = 0x9a,
+    OP_SWAP12 = 0x9b,
+    OP_SWAP13 = 0x9c,
+    OP_SWAP14 = 0x9d,
+    OP_SWAP15 = 0x9e,
+    OP_SWAP16 = 0x9f,
+    OP_LOG0 = 0xa0,
+    OP_LOG1 = 0xa1,
+    OP_LOG2 = 0xa2,
+    OP_LOG3 = 0xa3,
+    OP_LOG4 = 0xa4,
+
+    OP_CREATE = 0xf0,
+    OP_CALL = 0xf1,
+    OP_CALLCODE = 0xf2,
+    OP_RETURN = 0xf3,
+    OP_DELEGATECALL = 0xf4,
+    OP_CREATE2 = 0xf5,
+
+    OP_STATICCALL = 0xfa,
+
+    OP_REVERT = 0xfd,
+    OP_INVALID = 0xfe,
+    OP_SELFDESTRUCT = 0xff
+};
+
+/**
+ * Metrics for an EVM 1 instruction.
+ *
+ * Small integer types are used here to make the tables of metrics smaller.
+ */
+struct evmc_instruction_metrics
+{
+    /** The instruction gas cost. */
+    int16_t gas_cost;
+
+    /** The minimum number of the EVM stack items required for the instruction. */
+    int8_t stack_height_required;
+
+    /**
+     * The EVM stack height change caused by the instruction execution,
+     * i.e. stack height _after_ execution - stack height _before_ execution.
+     */
+    int8_t stack_height_change;
+};
+
+/**
+ * Get the table of the EVM 1 instructions metrics.
+ *
+ * @param revision  The EVM revision.
+ * @return          The pointer to the array of 256 instruction metrics. Null pointer in case
+ *                  an invalid EVM revision provided.
+ */
+EVMC_EXPORT const struct evmc_instruction_metrics* evmc_get_instruction_metrics_table(
+    enum evmc_revision revision);
+
+/**
+ * Get the table of the EVM 1 instruction names.
+ *
+ * The entries for undefined instructions contain null pointers.
+ *
+ * @param revision  The EVM revision.
+ * @return          The pointer to the array of 256 instruction names. Null pointer in case
+ *                  an invalid EVM revision provided.
+ */
+EVMC_EXPORT const char* const* evmc_get_instruction_names_table(enum evmc_revision revision);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/tests/evmc_c/utils.h
+++ b/tests/evmc_c/utils.h
@@ -1,0 +1,36 @@
+/* EVMC: Ethereum Client-VM Connector API.
+ * Copyright 2018-2019 The EVMC Authors.
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+#pragma once
+
+/**
+ * @file
+ * A collection of helper macros to handle some non-portable features of C/C++ compilers.
+ *
+ * @addtogroup helpers
+ * @{
+ */
+
+/**
+ * @def EVMC_EXPORT
+ * Marks a function to be exported from a shared library.
+ */
+#if defined _MSC_VER || defined __MINGW32__
+#define EVMC_EXPORT __declspec(dllexport)
+#else
+#define EVMC_EXPORT __attribute__((visibility("default")))
+#endif
+
+/**
+ * @def EVMC_NOEXCEPT
+ * Safe way of marking a function with `noexcept` C++ specifier.
+ */
+#ifdef __cplusplus
+#define EVMC_NOEXCEPT noexcept
+#else
+#define EVMC_NOEXCEPT
+#endif
+
+/** @} */

--- a/tests/test_host_vm.nim
+++ b/tests/test_host_vm.nim
@@ -7,7 +7,7 @@ import stew/byteutils
 {.passL: "-lstdc++"}
 
 when defined(posix):
-  {.passC: "-std=c++11".}
+  {.passC: "-std=c++14".}
 
 proc example_host_get_interface(): ptr evmc_host_interface {.importc, cdecl.}
 proc example_host_create_context(tx_context: var evmc_tx_context): evmc_host_context {.importc, cdecl.}


### PR DESCRIPTION
The only specification change from EVMC 7.1.0 to 7.5.0 is a new error code `EVM_INSUFFICIENT_BALANCE` which the EVM can return. This ABI change is backward compatible with older 7.x.y EVMS.

There are of course other changes from updating the C/C++ parts, notably the example VM is now a simplified EVM interpreter.