### PR TITLE
Update broken links, README format, copyright notices etc for licensing (no change to the actual license)

### DIFF
--- a/LICENSE-APACHEv2
+++ b/LICENSE-APACHEv2
@@ -1,3 +1,9 @@
+Nim EVMC is licensed under either of Apache License, version 2.0
+or the MIT License at your option.  See the top-level README file.
+
+Copyright (C) 2018-2019, 2021 Status Research & Development GmbH
+----------------------------------------------------------------
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -186,7 +192,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Status Research & Development GmbH
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,27 @@
+Nim EVMC is licensed under either of Apache License, version 2.0
+or the MIT License at your option.  See the top-level README file.
+
+Copyright (C) 2018-2019, 2021 Status Research & Development GmbH
+----------------------------------------------------------------
+
+The MIT License (MIT)
+
+Copyright (C) 2018-2019, 2021 Status Research & Development GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -24,5 +24,11 @@ This package is licensed under either of
 - Apache License, version 2.0, ([LICENSE-APACHEv2](LICENSE-APACHEv2))
 - MIT license ([LICENSE-MIT](LICENSE-MIT))
 
-at your option. The files in this package may not be copied, modified, or
-distributed except according to those terms.
+at your option. The files in this package (except those mentioned below) may
+not be copied, modified, or distributed except according to those terms.
+
+Files under subdirectory `tests/evmc_c` are third-party files from [Ethereum
+Client-VM Connector API (EVMC)](https://github.com/ethereum/evmc), and may only
+be used, copied, modified or distributed according to the licensing terms of
+that distribution.  Those terms are the Apache License, version 2.0,
+([LICENSE-APACHEv2](LICENSE-APACHEv2)).

--- a/README.md
+++ b/README.md
@@ -19,12 +19,10 @@ with `add_library(evmjit SHARED ${SOURCES} gen/BuildInfo.gen.h)` in libevmjit/CM
 
 ## License
 
-Licensed and distributed under either of
+This package is licensed under either of
 
-* MIT license: [LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT
+- Apache License, version 2.0, ([LICENSE-APACHEv2](LICENSE-APACHEv2))
+- MIT license ([LICENSE-MIT](LICENSE-MIT))
 
-or
-
-* Apache License, Version 2.0, ([LICENSE-APACHEv2](LICENSE-APACHEv2) or http://www.apache.org/licenses/LICENSE-2.0)
-
-at your option. This file may not be copied, modified, or distributed except according to those terms.
+at your option. The files in this package may not be copied, modified, or
+distributed except according to those terms.

--- a/evmc/evmc.nim
+++ b/evmc/evmc.nim
@@ -162,6 +162,7 @@ type
     # EVMC_ARGUMENT_OUT_OF_RANGE
     # EVMC_WASM_UNREACHABLE_INSTRUCTION
     # EVMC_WASM_TRAP
+    # EVMC_INSUFFICIENT_BALANCE
     # EVMC_INTERNAL_ERROR
     # EVMC_REJECTED
     # EVMC_OUT_OF_MEMORY
@@ -663,6 +664,9 @@ const
   # A WebAssembly trap has been hit during execution. This can be for many
   # reasons, including division by zero, validation errors, etc.
   EVMC_WASM_TRAP* = 16.evmc_status_code
+
+  # The caller does not have enough funds for value transfer. */
+  EVMC_INSUFFICIENT_BALANCE = 17.evmc_status_code
 
   # EVM implementation generic internal error.
   EVMC_INTERNAL_ERROR* = evmc_status_code(-1)

--- a/evmc/evmc.nim
+++ b/evmc/evmc.nim
@@ -42,7 +42,7 @@ type
   evmc_call_kind* {.size: sizeof(cint).} = enum
     EVMC_CALL = 0         # Request CALL.
     EVMC_DELEGATECALL = 1 # Request DELEGATECALL. Valid since Homestead.
-                          #  The value param ignored.
+                          # The value param ignored.
     EVMC_CALLCODE = 2     # Request CALLCODE.
     EVMC_CREATE = 3       # Request CREATE.
     EVMC_CREATE2 = 4      # Request CREATE2. Valid since Constantinople.
@@ -187,24 +187,26 @@ type
     # The execution status code.
     status_code*: evmc_status_code
 
-    #The amount of gas left after the execution.
-    # If evmc_result::code is not ::EVMC_SUCCESS nor ::EVMC_REVERT
+    # The amount of gas left after the execution.
+    #
+    # If evmc_result::code is neither ::EVMC_SUCCESS nor ::EVMC_REVERT
     # the value MUST be 0.
     gas_left*: int64
 
     # The reference to output data.
     #
-    #  The output contains data coming from RETURN opcode (iff evmc_result::code
-    #  field is ::EVMC_SUCCESS) or from REVERT opcode.
+    # The output contains data coming from RETURN opcode (iff evmc_result::code
+    # field is ::EVMC_SUCCESS) or from REVERT opcode.
     #
-    #  The memory containing the output data is owned by EVM and has to be
-    #  freed with evmc_result::release().
+    # The memory containing the output data is owned by EVM and has to be
+    # freed with evmc_result::release().
     #
-    #  This MAY be NULL.
+    # This MAY be NULL.
     output_data*: ptr byte
 
     # The size of the output data.
-    #  If output_data is NULL this MUST be 0.
+    #
+    # If output_data is NULL this MUST be 0.
     output_size*: uint
 
     # The method releasing all resources associated with the result object.
@@ -233,18 +235,17 @@ type
     # - and the result describes successful contract creation
     #   (evmc_result::status_code is ::EVMC_SUCCESS).
     # In all other cases the address MUST be null bytes.
-    #
     create_address*: evmc_address
 
     # Reserved data that MAY be used by a evmc_result object creator.
     #
-    #  This reserved 4 bytes together with 20 bytes from create_address form
-    #  24 bytes of memory called "optional data" within evmc_result struct
-    #  to be optionally used by the evmc_result object creator.
+    # This reserved 4 bytes together with 20 bytes from create_address form
+    # 24 bytes of memory called "optional data" within evmc_result struct
+    # to be optionally used by the evmc_result object creator.
     #
-    #  @see evmc_result_optional_data, evmc_get_optional_data().
+    # @see evmc_result_optional_data, evmc_get_optional_data().
     #
-    #  Also extends the size of the evmc_result to 64 bytes (full cache line).
+    # Also extends the size of the evmc_result to 64 bytes (full cache line).
     padding*: array[4, byte]
 
   # Check account existence callback function.

--- a/evmc/evmc.nim
+++ b/evmc/evmc.nim
@@ -1,11 +1,11 @@
-# Nimbus
-# Copyright (c) 2019 Status Research & Development GmbH
+# Nimbus - EVMC binary compatible interface
+#
+# Copyright (C) 2018-2019, 2021 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
-# at your option.
-# This file may not be copied, modified, or distributed except according to
-# those terms.
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
 
 
 # The EVMC ABI version number of the interface declared in this file.

--- a/evmc/evmc_nim.nim
+++ b/evmc/evmc_nim.nim
@@ -1,3 +1,13 @@
+# Nimbus - EVMC binary compatible interface
+#
+# Copyright (C) 2018-2019, 2021 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+
 import evmc
 
 type

--- a/tests/evmc_c/README.md
+++ b/tests/evmc_c/README.md
@@ -1,0 +1,7 @@
+# License of third-party files
+
+Files in this directory are third-party files from [Ethereum Client-VM
+Connector API (EVMC)](https://github.com/ethereum/evmc), and may only be used,
+copied, modified or distributed according to the licensing terms of that
+distribution.  Those terms are the Apache License, version 2.0,
+([LICENSE-APACHEv2](../../LICENSE-APACHEv2)).

--- a/tests/evmc_nim/nim_host.nim
+++ b/tests/evmc_nim/nim_host.nim
@@ -1,3 +1,13 @@
+# Nimbus - EVMC binary compatible interface
+#
+# Copyright (C) 2018-2019, 2021 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+
 import tables, hashes, strutils
 import ../../evmc/evmc
 import stew/byteutils

--- a/tests/test_host_vm.nim
+++ b/tests/test_host_vm.nim
@@ -1,3 +1,13 @@
+# Nimbus - EVMC binary compatible interface
+#
+# Copyright (C) 2018-2019, 2021 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+
 import ../evmc/[evmc, evmc_nim], unittest
 import evmc_nim/nim_host
 import stew/byteutils


### PR DESCRIPTION
This PR doesn't change the stated license, which is still dual-licensed Apache v2 or MIT like the rest of Nimbus.

It just fixes missing `LICENSE` files and a broken link to one, adds copyright notices to some files, updates years, and and reformats the `README` section to resemble what is used in other Nimbus projects.