### PR TITLE
Changes to types used in the EVMC binary interface

### DIFF
--- a/evmc/evmc.nim
+++ b/evmc/evmc.nim
@@ -707,9 +707,18 @@ typedef char enum_small_range_size_check[1-2*!(
 #   ld: symbol(s) not found for architecture x86_64
 #   clang: error: linker command failed with exit code 1 (use -v to see invocation)
 #
-proc `$`*(a: evmc_flags | evmc_capabilities): string =
+proc toString(a: evmc_flags | evmc_capabilities): string =
   var firstElement = true
   for value in items(a):
     result.add(if result.len == 0: "{" else: ", ")
     result.addQuoted(value)
   result.add(if result.len == 0: "{}" else: "}")
+
+# Workaround Nim <= 1.2.x giving "ambiguous call" if the above overloads `$` directly:
+#
+#   Error: ambiguous call; both dollars.$(x: set[T]) [declared in .../Nim/lib/system/dollars.nim(124, 6)]
+#          and evmc.$(a: evmc_flags or evmc_capabilities) [declared in .../evmc.nim(813, 6)]
+#          match for: (evmc_flags)
+#
+proc `$`*(a: evmc_flags): string = a.toString()
+proc `$`*(a: evmc_capabilities): string = a.toString()

--- a/evmc/evmc.nim
+++ b/evmc/evmc.nim
@@ -69,9 +69,12 @@ type
     EVMC_CREATE = 3       # Request CREATE.
     EVMC_CREATE2 = 4      # Request CREATE2. Valid since Constantinople.
 
-  # The flags for ::evmc_message.
-  evmc_flags* {.size: sizeof(cint).} = enum
-    EVMC_STATIC = 1  # Static call mode.
+  # The flags for ::evmc_message. (Bit shift positions).
+  evmc_flag_bit_shifts* = enum
+    EVMC_STATIC = 0       # Static call mode.
+
+  # The flags for ::evmc_message. (Nim bitset).
+  evmc_flags* {.size: sizeof(uint32).} = set[evmc_flag_bit_shifts]
 
   # The message describing an EVM call,
   # including a zero-depth calls from a transaction origin.
@@ -81,7 +84,7 @@ type
 
     # Additional flags modifying the call execution behavior.
     # In the current version the only valid values are ::EVMC_STATIC or 0.
-    flags*: uint32
+    flags*: evmc_flags
 
     # The call depth.
     depth*: int32

--- a/evmc/evmc.nim
+++ b/evmc/evmc.nim
@@ -35,6 +35,18 @@ when defined(cpp):
 else:
   type c99bool* {.importc: "bool", header: "<stdbool.h>".} = bool
 
+# EVMC uses C `enum` types as parameters and in structures.
+#
+# Although these are nearly always the size of C `int`, a few targets default
+# to `char` (because all the enum values fit).  Just our luck, it's some 32-bit
+# ARM ABIs (AAPCS and BPAPI); but not Linux, FreeBSD or NetBSD.  It is `char`
+# on 32-bit ARM Google Fuchsia, which we might realistically encounter, and
+# some embedded system CPUs.
+#
+# We'll assume C `int`.  If you run on those 32-bit ARMs and EVMC doesn't work,
+# this comment and type may prove useful.
+type cenum_small_range = cint
+
 type
   # The fixed size array of 32 bytes.
   # 32 bytes of data capable of storing e.g. 256-bit hashes.
@@ -49,7 +61,7 @@ type
     bytes*: array[20, byte]
 
   # The kind of call-like instruction.
-  evmc_call_kind* {.size: sizeof(cint).} = enum
+  evmc_call_kind* {.size: sizeof(cenum_small_range).} = enum
     EVMC_CALL = 0         # Request CALL.
     EVMC_DELEGATECALL = 1 # Request DELEGATECALL. Valid since Homestead.
                           # The value param ignored.
@@ -154,7 +166,7 @@ type
   # @note
   # In case new status codes are needed, please create an issue or pull request
   # in the EVMC repository (https://github.com/ethereum/evmc).
-  evmc_status_code* {.size: sizeof(cint).} = enum
+  evmc_status_code* {.size: sizeof(cenum_small_range).} = enum
     # The VM failed to allocate the amount of memory needed for execution.
     EVMC_OUT_OF_MEMORY = -3
 
@@ -353,7 +365,7 @@ type
   # - Y != X, Y != 0 (Y is any value other than X and 0),
   # - Z != Y (Z is any value other than Y),
   # - the "->" means the change from one value to another.
-  evmc_storage_status* {.size: sizeof(cint).} = enum
+  evmc_storage_status* {.size: sizeof(cenum_small_range).} = enum
     # The value of a storage item has been left unchanged: 0 -> 0 and X -> X.
     EVMC_STORAGE_UNCHANGED = 0
 
@@ -514,7 +526,7 @@ type
   evmc_destroy_fn* = proc(vm: ptr evmc_vm) {.cdecl.}
 
   # Possible outcomes of evmc_set_option.
-  evmc_set_option_result* {.size: sizeof(cint).} = enum
+  evmc_set_option_result* {.size: sizeof(cenum_small_range).} = enum
     EVMC_SET_OPTION_SUCCESS = 0
     EVMC_SET_OPTION_INVALID_NAME = 1
     EVMC_SET_OPTION_INVALID_VALUE = 2
@@ -536,7 +548,7 @@ type
   #
   # The revision of the EVM specification based on the Ethereum
   # upgrade / hard fork codenames.
-  evmc_revision* {.size: sizeof(cint).} = enum
+  evmc_revision* {.size: sizeof(cenum_small_range).} = enum
     # The Frontier revision.
     # The one Ethereum launched with.
     EVMC_FRONTIER = 0

--- a/evmc/evmc.nim
+++ b/evmc/evmc.nim
@@ -609,11 +609,26 @@ type
                           context: evmc_host_context, rev: evmc_revision,
                           msg: evmc_message, code: ptr byte, code_size: csize_t): evmc_result {.cdecl.}
 
-  # Possible capabilities of a VM.
-  evmc_capabilities* = distinct uint32
-    # EVMC_CAPABILITY_EVM1
-    # EVMC_CAPABILITY_EWASM
-    # EVMC_CAPABILITY_PRECOMPILES
+  # Possible capabilities of a VM. (Bit shift positions).
+  evmc_capability_bit_shifts* = enum
+    # The VM is capable of executing EVM1 bytecode.
+    EVMC_CAPABILITY_EVM1 = 0
+
+    # The VM is capable of executing ewasm bytecode.
+    EVMC_CAPABILITY_EWASM = 1
+
+    # The VM is capable of executing the precompiled contracts
+    # defined for the range of destination addresses.
+    #
+    # The EIP-1352 (https://eips.ethereum.org/EIPS/eip-1352) specifies
+    # the range 0x000...0000 - 0x000...ffff of addresses
+    # reserved for precompiled and system contracts.
+    #
+    # This capability is **experimental** and MAY be removed without notice.
+    EVMC_CAPABILITY_PRECOMPILES = 2
+
+  # Possible capabilities of a VM. (Nim bitset).
+  evmc_capabilities* {.size: sizeof(uint32).} = set[evmc_capability_bit_shifts]
 
   # Return the supported capabilities of the VM instance.
   #
@@ -674,15 +689,6 @@ type
 const
   # The maximum EVM revision supported.
   EVMC_MAX_REVISION* = EVMC_BERLIN
-
-proc incl*(a: var evmc_capabilities, b: evmc_capabilities) {.inline.} =
-  a = evmc_capabilities(a.uint32 or b.uint32)
-
-proc excl*(a: var evmc_capabilities, b: evmc_capabilities) {.inline.} =
-  a = evmc_capabilities(a.uint32 and (not b.uint32))
-
-proc contains*(a, b: evmc_capabilities): bool {.inline.} =
-  (a.uint32 and b.uint32) != 0
 
 # Check small-range enums have C `int` size, so the definitions in this file
 # are binary compatible with EVMC API in `evmc.h`.  On almost all targets it's

--- a/evmc/evmc.nim
+++ b/evmc/evmc.nim
@@ -90,7 +90,7 @@ type
     # The size of the message input data.
     # If input_data is NULL this MUST be 0.
     # actually it's a size_t
-    input_size*: uint
+    input_size*: csize_t
 
     # The amount of Ether transferred with the message.
     value*: evmc_uint256be
@@ -218,7 +218,7 @@ type
     # The size of the output data.
     #
     # If output_data is NULL this MUST be 0.
-    output_size*: uint
+    output_size*: csize_t
 
     # The method releasing all resources associated with the result object.
     #
@@ -336,7 +336,7 @@ type
   # @param context  The pointer to the Host execution context.
   # @param address  The address of the account.
   # @return         The size of the code in the account or 0 if the account does not exist.
-  evmc_get_code_size_fn* = proc(context: evmc_host_context, address: ptr evmc_address): uint {.cdecl.}
+  evmc_get_code_size_fn* = proc(context: evmc_host_context, address: ptr evmc_address): csize_t {.cdecl.}
 
   # Get code hash callback function.
   #
@@ -365,8 +365,8 @@ type
   # @param buffer_size  The size of the memory buffer.
   # @return             The number of bytes copied to the buffer by the Client.
   evmc_copy_code_fn* = proc(context: evmc_host_context, address: ptr evmc_address,
-                            code_offset: uint, buffer_data: ptr byte,
-                            buffer_size: uint): uint {.cdecl.}
+                            code_offset: csize_t, buffer_data: ptr byte,
+                            buffer_size: csize_t): csize_t {.cdecl.}
 
   # Selfdestruct callback function.
   #
@@ -390,8 +390,8 @@ type
   # @param topics        The pointer to the array of topics attached to the log.
   # @param topics_count  The number of the topics. Valid values are between 0 and 4 inclusively.
   evmc_emit_log_fn* = proc(context: evmc_host_context, address: ptr evmc_address,
-                           data: ptr byte, data_size: uint,
-                           topics: ptr evmc_bytes32, topics_count: uint) {.cdecl.}
+                           data: ptr byte, data_size: csize_t,
+                           topics: ptr evmc_bytes32, topics_count: csize_t) {.cdecl.}
 
   # Pointer to the callback function supporting EVM calls.
   #
@@ -527,7 +527,7 @@ type
   # @return           The execution result.
   evmc_execute_fn* = proc(vm: ptr evmc_vm, host: ptr evmc_host_interface,
                           context: evmc_host_context, rev: evmc_revision,
-                          msg: evmc_message, code: ptr byte, code_size: uint): evmc_result {.cdecl.}
+                          msg: evmc_message, code: ptr byte, code_size: csize_t): evmc_result {.cdecl.}
 
   # Possible capabilities of a VM.
   evmc_capabilities* = distinct uint32

--- a/evmc/evmc.nim
+++ b/evmc/evmc.nim
@@ -698,3 +698,18 @@ const
 typedef char enum_small_range_size_check[1-2*!(
   sizeof(enum small_range) == """ & $sizeof(cenum_small_range) & """
 )];""".}
+
+# Provide `$` to workaround Nim bug with `uint32`-sized bitset and default `$`:
+#
+#   Undefined symbols for architecture x86_64:
+#     "dollar___QwZMdq3JxuE8Rzg1sj1eCA(unsigned int)", referenced from:
+#         main__ixGWZtZ2B0S7ftxfYJLaUw() in @mtest_host_vm.nim.cpp.o
+#   ld: symbol(s) not found for architecture x86_64
+#   clang: error: linker command failed with exit code 1 (use -v to see invocation)
+#
+proc `$`*(a: evmc_flags | evmc_capabilities): string =
+  var firstElement = true
+  for value in items(a):
+    result.add(if result.len == 0: "{" else: ", ")
+    result.addQuoted(value)
+  result.add(if result.len == 0: "{}" else: "}")

--- a/evmc/evmc_nim.nim
+++ b/evmc/evmc_nim.nim
@@ -55,17 +55,17 @@ proc copyCode*(ctx: HostContext, address: evmc_address, codeOffset: int = 0): se
   let size = ctx.getCodeSize(address)
   if size - codeOffset > 0:
     result = newSeq[byte](size - codeOffset)
-    let read = ctx.host.copy_code(ctx.context, address.unsafeAddr, code_offset.uint, result[0].addr, result.len.uint).int
+    let read = ctx.host.copy_code(ctx.context, address.unsafeAddr, code_offset.csize_t, result[0].addr, result.len.csize_t).int
     doAssert(read == result.len)
 
 proc copyCode*(ctx: HostContext, address: evmc_address, codeOffset: int, output: ptr byte, output_len: int): int =
-  ctx.host.copy_code(ctx.context, address.unsafeAddr, code_offset.uint, output, output_len.uint).int
+  ctx.host.copy_code(ctx.context, address.unsafeAddr, code_offset.csize_t, output, output_len.csize_t).int
 
 proc selfdestruct*(ctx: HostContext, address, beneficiary: evmc_address) =
   ctx.host.selfdestruct(ctx.context, address.unsafeAddr, beneficiary.unsafeAddr)
 
 proc emitLog*(ctx: HostContext, address: evmc_address, data: openArray[byte], topics: openArray[evmc_bytes32]) =
-  ctx.host.emit_log(ctx.context, address.unsafeAddr, data[0].unsafeAddr, data.len.uint, topics[0].unsafeAddr, topics.len.uint)
+  ctx.host.emit_log(ctx.context, address.unsafeAddr, data[0].unsafeAddr, data.len.csize_t, topics[0].unsafeAddr, topics.len.csize_t)
 
 proc call*(ctx: HostContext, msg: evmc_message): evmc_result =
   ctx.host.call(ctx.context, msg.unsafeAddr)
@@ -99,7 +99,7 @@ proc setOption*(vm: EvmcVM, name, value: string): evmc_set_option_result =
   result = EVMC_SET_OPTION_INVALID_NAME
 
 proc execute*(vm: EvmcVM, rev: evmc_revision, msg: evmc_message, code: openArray[byte]): evmc_result =
-  vm.vm.execute(vm.vm, vm.hc.host, vm.hc.context, rev, msg, code[0].unsafeAddr, code.len.uint)
+  vm.vm.execute(vm.vm, vm.hc.host, vm.hc.context, rev, msg, code[0].unsafeAddr, code.len.csize_t)
 
 proc destroy*(vm: EvmcVM) =
   vm.vm.destroy(vm.vm)

--- a/tests/evmc_nim/nim_host.nim
+++ b/tests/evmc_nim/nim_host.nim
@@ -71,17 +71,17 @@ proc evmcGetBalanceImpl(ctx: HostContext, address: var evmc_address): evmc_uint2
   if address in ctx.accounts:
     result = ctx.accounts[address].balance
 
-proc evmcGetCodeSizeImpl(ctx: HostContext, address: var evmc_address): uint {.cdecl.} =
+proc evmcGetCodeSizeImpl(ctx: HostContext, address: var evmc_address): csize_t {.cdecl.} =
   if address in ctx.accounts:
-    result = ctx.accounts[address].code.len.uint
+    result = ctx.accounts[address].code.len.csize_t
 
 proc evmcGetCodeHashImpl(ctx: HostContext, address: var evmc_address): evmc_bytes32 {.cdecl.} =
   if address in ctx.accounts:
     result = ctx.accounts[address].codeHash()
 
 proc evmcCopyCodeImpl(ctx: HostContext, address: var evmc_address,
-                            code_offset: uint, buffer_data: ptr byte,
-                            buffer_size: uint): uint {.cdecl.} =
+                            code_offset: csize_t, buffer_data: ptr byte,
+                            buffer_size: csize_t): csize_t {.cdecl.} =
 
   if address notin ctx.accounts:
     return 0
@@ -93,14 +93,14 @@ proc evmcCopyCodeImpl(ctx: HostContext, address: var evmc_address,
   let n = min(buffer_size.int, acc.code.len - code_offset.int)
   if n > 0:
     copyMem(buffer_data, acc.code[code_offset].addr, n)
-  result = n.uint
+  result = n.csize_t
 
 proc evmcSelfdestructImpl(ctx: HostContext, address, beneficiary: var evmc_address) {.cdecl.} =
   discard
 
 proc evmcEmitLogImpl(ctx: HostContext, address: var evmc_address,
-                           data: ptr byte, data_size: uint,
-                           topics: ptr evmc_bytes32, topics_count: uint) {.cdecl.} =
+                           data: ptr byte, data_size: csize_t,
+                           topics: ptr evmc_bytes32, topics_count: csize_t) {.cdecl.} =
   discard
 
 proc evmcCallImpl(ctx: HostContext, msg: var evmc_message): evmc_result {.cdecl.} =
@@ -122,7 +122,7 @@ proc evmcSetOptionImpl(vm: ptr evmc_vm, name, value: cstring): evmc_set_option_r
 
 proc evmcExecuteImpl(vm: ptr evmc_vm, host: ptr evmc_host_interface,
                           ctx: HostContext, rev: evmc_revision,
-                          msg: evmc_message, code: ptr byte, code_size: uint): evmc_result {.cdecl.} =
+                          msg: evmc_message, code: ptr byte, code_size: csize_t): evmc_result {.cdecl.} =
 
   var the_code = "\x43\x60\x00\x55\x43\x60\x00\x52\x59\x60\x00\xf3"
   const the_gas_used = 9 # Count the instructions, same as the C++ fake EVM.
@@ -141,7 +141,7 @@ proc evmcExecuteImpl(vm: ptr evmc_vm, host: ptr evmc_host_interface,
     result.status_code = EVMC_SUCCESS
     result.gas_left = msg.gas - the_gas_used
     result.output_data = cast[ptr byte](output_data)
-    result.output_size = output_size.uint
+    result.output_size = output_size.csize_t
     result.release = evmcReleaseResultImpl
     return
 

--- a/tests/evmc_nim/nim_host.nim
+++ b/tests/evmc_nim/nim_host.nim
@@ -149,8 +149,7 @@ proc evmcExecuteImpl(vm: ptr evmc_vm, host: ptr evmc_host_interface,
   result.gas_left = 0
 
 proc evmcGetCapabilitiesImpl(vm: ptr evmc_vm): evmc_capabilities {.cdecl.} =
-  result.incl(EVMC_CAPABILITY_EVM1)
-  result.incl(EVMC_CAPABILITY_EWASM)
+  result = {EVMC_CAPABILITY_EVM1, EVMC_CAPABILITY_EWASM}
 
 proc evmcDestroyImpl(vm: ptr evmc_vm) {.cdecl.} =
   dealloc(vm)

--- a/tests/evmc_nim/nim_host.nim
+++ b/tests/evmc_nim/nim_host.nim
@@ -149,7 +149,7 @@ proc evmcExecuteImpl(vm: ptr evmc_vm, host: ptr evmc_host_interface,
   result.gas_left = 0
 
 proc evmcGetCapabilitiesImpl(vm: ptr evmc_vm): evmc_capabilities {.cdecl.} =
-  result = {EVMC_CAPABILITY_EVM1, EVMC_CAPABILITY_EWASM}
+  result = {EVMC_CAPABILITY_EVM1, EVMC_CAPABILITY_PRECOMPILES}
 
 proc evmcDestroyImpl(vm: ptr evmc_vm) {.cdecl.} =
   dealloc(vm)

--- a/tests/test_host_vm.nim
+++ b/tests/test_host_vm.nim
@@ -91,7 +91,7 @@ template runTest(testName: string, create_vm, get_host_interface, create_host_co
     destination: address,
     value: balance,
     input_data: cast[ptr byte](input[0].addr),
-    input_size: input.len.uint,
+    input_size: input.len.csize_t,
     gas: gas,
     depth: 0
   )

--- a/tests/test_host_vm.nim
+++ b/tests/test_host_vm.nim
@@ -87,6 +87,7 @@ template runTest(testName: string, create_vm, get_host_interface, create_host_co
 
   var msg = evmc_message(
     kind: EVMC_CALL,
+    flags: {EVMC_STATIC},
     sender: address,
     destination: address,
     value: balance,

--- a/tests/test_host_vm.nim
+++ b/tests/test_host_vm.nim
@@ -178,13 +178,14 @@ template runTest(testName: string, create_vm, get_host_interface, create_host_co
     test "getCapabilities":
       let cap = nvm.getCapabilities()
       check EVMC_CAPABILITY_EVM1 in cap
+      check EVMC_CAPABILITY_EWASM notin cap
       check create_vm == evmc_create_example_vm or create_vm == nim_create_example_vm
       if create_vm == evmc_create_example_vm:
-        # The C++ fake VM doesn't claim to support EWASM and we won't change that.
-        check EVMC_CAPABILITY_EWASM notin cap
+        # The C++ fake VM doesn't claim to support PRECOMPILES and we won't change that.
+        check EVMC_CAPABILITY_PRECOMPILES notin cap
       else:
-        # But set EWASM bit in the Nim fake VM, just to verify more bits get through.
-        check EVMC_CAPABILITY_EWASM in cap
+        # But set PROCOMPILES bit in the Nim fake VM, just to verify more bits get through.
+        check EVMC_CAPABILITY_PRECOMPILES in cap
 
     test "setOption":
       check nvm.setOption("verbose", "2") == EVMC_SET_OPTION_SUCCESS


### PR DESCRIPTION
- Use `csize_t` in appropriate places to match the C version of EVMC API
- Recognise that target C enums aren't always `cint`, which would cause weird bugs on some targets
  - (32-bit ARM is usually the issue)
- Check size of C enum at compile time matches assumption in Nim code
- Make `evmc_status_code` a normal enum
- Make `evmc_flags` use a Nim bitset
- Make `evmc_capabilities` use a Nim bitset
- Fun workarounds for bugs in Nim with `uint32`-size bitsets