### PR TITLE
Small improvements in the tests

### DIFF
--- a/tests/evmc_nim/nim_host.nim
+++ b/tests/evmc_nim/nim_host.nim
@@ -22,10 +22,10 @@ type
     tx_context: evmc_tx_context
     accounts: Table[evmc_address, Account]
 
-proc hash*(x: evmc_bytes32): Hash =
+proc hash(x: evmc_bytes32): Hash =
   result = hash(x.bytes)
 
-proc hash*(x: evmc_address): Hash =
+proc hash(x: evmc_address): Hash =
   result = hash(x.bytes)
 
 proc codeHash(acc: Account): evmc_bytes32 =

--- a/tests/test_host_vm.nim
+++ b/tests/test_host_vm.nim
@@ -9,8 +9,12 @@
 
 
 import ../evmc/[evmc, evmc_nim], unittest
-import evmc_nim/nim_host
 import stew/byteutils
+
+# This module must be imported to include it in the compile, but Nim thinks
+# it is unused because it's only called via `.exportc` -> `.importc`.
+{.warning[UnusedImport]: off.}:
+  import evmc_nim/nim_host
 
 {.compile: "evmc_c/example_host.cpp".}
 {.compile: "evmc_c/example_vm.cpp".}


### PR DESCRIPTION
- Remove unnecessary exports from the Nim example host/VM.

- Disable "Imported and not used" warning in test program, now there are no warnings.  This is a bit subtle:

  The Nim example host/VM module is only called via functions exported and imported at the C level with `.exportc` -> `.importc`.

  No symbols are used from the module at the Nim level, so Nim thinks it is an unused import and warns:

      Warning: imported and not used: 'nim_host' [UnusedImport]

  But we must import so the module is compiled into the program for the C functions to be available, so disable the warning for this one module.