### PR TITLE
While `ptr` is still the basis of the API, fix inconsistencies

### DIFF
--- a/evmc/evmc.nim
+++ b/evmc/evmc.nim
@@ -607,7 +607,7 @@ type
   # @return           The execution result.
   evmc_execute_fn* = proc(vm: ptr evmc_vm, host: ptr evmc_host_interface,
                           context: evmc_host_context, rev: evmc_revision,
-                          msg: evmc_message, code: ptr byte, code_size: csize_t): evmc_result {.cdecl.}
+                          msg: ptr evmc_message, code: ptr byte, code_size: csize_t): evmc_result {.cdecl.}
 
   # Possible capabilities of a VM. (Bit shift positions).
   evmc_capability_bit_shifts* = enum

--- a/evmc/evmc.nim
+++ b/evmc/evmc.nim
@@ -271,7 +271,7 @@ type
   # The result is passed by pointer to avoid (shallow) copy of the ::evmc_result
   # struct. Think of this as the best possible C language approximation to
   # passing objects by reference.
-  evmc_release_result_fn* = proc(result: var evmc_result) {.cdecl.}
+  evmc_release_result_fn* = proc(result: ptr evmc_result) {.cdecl.}
 
   # The EVM code execution result.
   evmc_result* = object

--- a/evmc/evmc_nim.nim
+++ b/evmc/evmc_nim.nim
@@ -99,7 +99,7 @@ proc setOption*(vm: EvmcVM, name, value: string): evmc_set_option_result =
   result = EVMC_SET_OPTION_INVALID_NAME
 
 proc execute*(vm: EvmcVM, rev: evmc_revision, msg: evmc_message, code: openArray[byte]): evmc_result =
-  vm.vm.execute(vm.vm, vm.hc.host, vm.hc.context, rev, msg, code[0].unsafeAddr, code.len.csize_t)
+  vm.vm.execute(vm.vm, vm.hc.host, vm.hc.context, rev, msg.unsafeAddr, code[0].unsafeAddr, code.len.csize_t)
 
 proc destroy*(vm: EvmcVM) =
   vm.vm.destroy(vm.vm)

--- a/evmc/evmc_nim.nim
+++ b/evmc/evmc_nim.nim
@@ -103,3 +103,7 @@ proc execute*(vm: EvmcVM, rev: evmc_revision, msg: evmc_message, code: openArray
 
 proc destroy*(vm: EvmcVM) =
   vm.vm.destroy(vm.vm)
+
+proc destroy*(res: var evmc_result) =
+  if not res.release.isNil:
+    res.release(res.unsafeAddr)

--- a/tests/evmc_nim/nim_host.nim
+++ b/tests/evmc_nim/nim_host.nim
@@ -34,7 +34,7 @@ proc codeHash(acc: Account): evmc_bytes32 =
     let idx = v.int mod sizeof(result.bytes)
     result.bytes[idx] = result.bytes[idx] xor v
 
-proc evmcReleaseResultImpl(result: var evmc_result) {.cdecl.} =
+proc evmcReleaseResultImpl(result: ptr evmc_result) {.cdecl.} =
   discard
 
 proc evmcGetTxContextImpl(ctx: HostContext): evmc_tx_context {.cdecl.} =

--- a/tests/test_host_vm.nim
+++ b/tests/test_host_vm.nim
@@ -216,7 +216,7 @@ template runTest(testName: string, create_vm, get_host_interface, create_host_co
         for i in bn.len..<res.output_size.int:
           let b = cast[ptr UncheckedArray[byte]](res.output_data)[i]
           check b == 0.byte
-      res.release(res)
+      res.destroy()
 
       var empty_key: evmc_bytes32
       let val = hc.getStorage(address, empty_key)


### PR DESCRIPTION
- Use `ptr` in release for API consistency

  Nearly all API functions use `ptr`, so change `release` to use it as well.

  Add a helper `res.destroy()` to the support API in `evmc_nim.nim` and use it in the test program.  It's a destructor so this is a fine name.  (We can't call it `res.release()` because that name conflicts with the object field.)

- Fix missing `ptr` in signature of execute

  It was just missing. Its absence didn't affect binary compatibility because Nim converts larger parameters to pass by reference anyway, but we were relying on Nim's heuristic. Adding `ptr` makes it explicit and matches the rest of the API.