### PR TITLE
Use `var` instead of `ptr` for arguments that are pass-by-ref

### DIFF
--- a/evmc/evmc.nim
+++ b/evmc/evmc.nim
@@ -271,7 +271,7 @@ type
   # The result is passed by pointer to avoid (shallow) copy of the ::evmc_result
   # struct. Think of this as the best possible C language approximation to
   # passing objects by reference.
-  evmc_release_result_fn* = proc(result: ptr evmc_result) {.cdecl.}
+  evmc_release_result_fn* = proc(result: var evmc_result) {.cdecl.}
 
   # The EVM code execution result.
   evmc_result* = object
@@ -346,7 +346,7 @@ type
   # @param context  The pointer to the Host execution context.
   # @param address  The address of the account the query is about.
   # @return         true if exists, false otherwise.
-  evmc_account_exists_fn* = proc(context: evmc_host_context, address: ptr evmc_address): c99bool {.cdecl.}
+  evmc_account_exists_fn* = proc(context: evmc_host_context, address: var evmc_address): c99bool {.cdecl.}
 
   #  Get storage callback function.
   #
@@ -357,7 +357,7 @@ type
   #  @param key      The index of the account's storage entry.
   #  @return         The storage value at the given storage key or null bytes
   #                  if the account does not exist.
-  evmc_get_storage_fn* = proc(context: evmc_host_context, address: ptr evmc_address, key: ptr evmc_bytes32): evmc_bytes32 {.cdecl.}
+  evmc_get_storage_fn* = proc(context: evmc_host_context, address: var evmc_address, key: var evmc_bytes32): evmc_bytes32 {.cdecl.}
 
   # The effect of an attempt to modify a contract storage item.
   #
@@ -396,8 +396,8 @@ type
   # @param key      The index of the storage entry.
   # @param value    The value to be stored.
   # @return         The effect on the storage item.
-  evmc_set_storage_fn* = proc(context: evmc_host_context, address: ptr evmc_address,
-                              key, value: ptr evmc_bytes32): evmc_storage_status {.cdecl.}
+  evmc_set_storage_fn* = proc(context: evmc_host_context, address: var evmc_address,
+                              key, value: var evmc_bytes32): evmc_storage_status {.cdecl.}
 
   # Get balance callback function.
   #
@@ -406,7 +406,7 @@ type
   # @param context  The pointer to the Host execution context.
   # @param address  The address of the account.
   # @return         The balance of the given account or 0 if the account does not exist.
-  evmc_get_balance_fn* = proc(context: evmc_host_context, address: ptr evmc_address): evmc_uint256be {.cdecl.}
+  evmc_get_balance_fn* = proc(context: evmc_host_context, address: var evmc_address): evmc_uint256be {.cdecl.}
 
   # Get code size callback function.
   #
@@ -416,7 +416,7 @@ type
   # @param context  The pointer to the Host execution context.
   # @param address  The address of the account.
   # @return         The size of the code in the account or 0 if the account does not exist.
-  evmc_get_code_size_fn* = proc(context: evmc_host_context, address: ptr evmc_address): csize_t {.cdecl.}
+  evmc_get_code_size_fn* = proc(context: evmc_host_context, address: var evmc_address): csize_t {.cdecl.}
 
   # Get code hash callback function.
   #
@@ -427,7 +427,7 @@ type
   # @param context  The pointer to the Host execution context.
   # @param address  The address of the account.
   # @return         The hash of the code in the account or null bytes if the account does not exist.
-  evmc_get_code_hash_fn* = proc(context: evmc_host_context, address: ptr evmc_address): evmc_bytes32 {.cdecl.}
+  evmc_get_code_hash_fn* = proc(context: evmc_host_context, address: var evmc_address): evmc_bytes32 {.cdecl.}
 
   # Copy code callback function.
   #
@@ -444,7 +444,7 @@ type
   #                     to store a copy of the requested code.
   # @param buffer_size  The size of the memory buffer.
   # @return             The number of bytes copied to the buffer by the Client.
-  evmc_copy_code_fn* = proc(context: evmc_host_context, address: ptr evmc_address,
+  evmc_copy_code_fn* = proc(context: evmc_host_context, address: var evmc_address,
                             code_offset: csize_t, buffer_data: ptr byte,
                             buffer_size: csize_t): csize_t {.cdecl.}
 
@@ -456,7 +456,7 @@ type
   # @param context      The pointer to the Host execution context. See ::evmc_host_context.
   # @param address      The address of the contract to be selfdestructed.
   # @param beneficiary  The address where the remaining ETH is going to be transferred.
-  evmc_selfdestruct_fn* = proc(context: evmc_host_context, address, beneficiary: ptr evmc_address) {.cdecl.}
+  evmc_selfdestruct_fn* = proc(context: evmc_host_context, address, beneficiary: var evmc_address) {.cdecl.}
 
   # Log callback function.
   #
@@ -469,7 +469,7 @@ type
   # @param data_size     The length of the data.
   # @param topics        The pointer to the array of topics attached to the log.
   # @param topics_count  The number of the topics. Valid values are between 0 and 4 inclusively.
-  evmc_emit_log_fn* = proc(context: evmc_host_context, address: ptr evmc_address,
+  evmc_emit_log_fn* = proc(context: evmc_host_context, address: var evmc_address,
                            data: ptr byte, data_size: csize_t,
                            topics: ptr evmc_bytes32, topics_count: csize_t) {.cdecl.}
 
@@ -478,7 +478,7 @@ type
   # @param context  The pointer to the Host execution context.
   # @param msg      The call parameters.
   # @return         The result of the call.
-  evmc_call_fn* = proc(context: evmc_host_context, msg: ptr evmc_message): evmc_result {.cdecl.}
+  evmc_call_fn* = proc(context: evmc_host_context, msg: var evmc_message): evmc_result {.cdecl.}
 
   # The Host interface.
   #
@@ -607,7 +607,7 @@ type
   # @return           The execution result.
   evmc_execute_fn* = proc(vm: ptr evmc_vm, host: ptr evmc_host_interface,
                           context: evmc_host_context, rev: evmc_revision,
-                          msg: ptr evmc_message, code: ptr byte, code_size: csize_t): evmc_result {.cdecl.}
+                          msg: var evmc_message, code: ptr byte, code_size: csize_t): evmc_result {.cdecl.}
 
   # Possible capabilities of a VM. (Bit shift positions).
   evmc_capability_bit_shifts* = enum

--- a/evmc/evmc_nim.nim
+++ b/evmc/evmc_nim.nim
@@ -32,43 +32,43 @@ proc getTxContext*(ctx: HostContext): evmc_tx_context =
 proc getBlockHash*(ctx: HostContext, number: int64): evmc_bytes32 =
   ctx.host.get_block_hash(ctx.context, number)
 
-proc accountExists*(ctx: HostContext, address: evmc_address): bool =
-  ctx.host.account_exists(ctx.context, address.unsafeAddr).bool
+proc accountExists*(ctx: HostContext, address: var evmc_address): bool =
+  ctx.host.account_exists(ctx.context, address).bool
 
-proc getStorage*(ctx: HostContext, address: evmc_address, key: evmc_bytes32): evmc_bytes32 =
-  ctx.host.get_storage(ctx.context, address.unsafeAddr, key.unsafeAddr)
+proc getStorage*(ctx: HostContext, address: var evmc_address, key: var evmc_bytes32): evmc_bytes32 =
+  ctx.host.get_storage(ctx.context, address, key)
 
-proc setStorage*(ctx: HostContext, address: evmc_address,
-                        key, value: evmc_bytes32): evmc_storage_status =
-  ctx.host.set_storage(ctx.context, address.unsafeAddr, key.unsafeAddr, value.unsafeAddr)
+proc setStorage*(ctx: HostContext, address: var evmc_address,
+                        key, value: var evmc_bytes32): evmc_storage_status =
+  ctx.host.set_storage(ctx.context, address, key, value)
 
-proc getBalance*(ctx: HostContext, address: evmc_address): evmc_uint256be =
-  ctx.host.get_balance(ctx.context, address.unsafeAddr)
+proc getBalance*(ctx: HostContext, address: var evmc_address): evmc_uint256be =
+  ctx.host.get_balance(ctx.context, address)
 
-proc getCodeSize*(ctx: HostContext, address: evmc_address): int =
-  ctx.host.get_code_size(ctx.context, address.unsafeAddr).int
+proc getCodeSize*(ctx: HostContext, address: var evmc_address): int =
+  ctx.host.get_code_size(ctx.context, address).int
 
-proc getCodeHash*(ctx: HostContext, address: evmc_address): evmc_bytes32 =
-  ctx.host.get_code_hash(ctx.context, address.unsafeAddr)
+proc getCodeHash*(ctx: HostContext, address: var evmc_address): evmc_bytes32 =
+  ctx.host.get_code_hash(ctx.context, address)
 
-proc copyCode*(ctx: HostContext, address: evmc_address, codeOffset: int = 0): seq[byte] =
+proc copyCode*(ctx: HostContext, address: var evmc_address, codeOffset: int = 0): seq[byte] =
   let size = ctx.getCodeSize(address)
   if size - codeOffset > 0:
     result = newSeq[byte](size - codeOffset)
-    let read = ctx.host.copy_code(ctx.context, address.unsafeAddr, code_offset.csize_t, result[0].addr, result.len.csize_t).int
+    let read = ctx.host.copy_code(ctx.context, address, code_offset.csize_t, result[0].addr, result.len.csize_t).int
     doAssert(read == result.len)
 
-proc copyCode*(ctx: HostContext, address: evmc_address, codeOffset: int, output: ptr byte, output_len: int): int =
-  ctx.host.copy_code(ctx.context, address.unsafeAddr, code_offset.csize_t, output, output_len.csize_t).int
+proc copyCode*(ctx: HostContext, address: var evmc_address, codeOffset: int, output: ptr byte, output_len: int): int =
+  ctx.host.copy_code(ctx.context, address, code_offset.csize_t, output, output_len.csize_t).int
 
-proc selfdestruct*(ctx: HostContext, address, beneficiary: evmc_address) =
-  ctx.host.selfdestruct(ctx.context, address.unsafeAddr, beneficiary.unsafeAddr)
+proc selfdestruct*(ctx: HostContext, address, beneficiary: var evmc_address) =
+  ctx.host.selfdestruct(ctx.context, address, beneficiary)
 
-proc emitLog*(ctx: HostContext, address: evmc_address, data: openArray[byte], topics: openArray[evmc_bytes32]) =
-  ctx.host.emit_log(ctx.context, address.unsafeAddr, data[0].unsafeAddr, data.len.csize_t, topics[0].unsafeAddr, topics.len.csize_t)
+proc emitLog*(ctx: HostContext, address: var evmc_address, data: openArray[byte], topics: openArray[evmc_bytes32]) =
+  ctx.host.emit_log(ctx.context, address, data[0].unsafeAddr, data.len.csize_t, topics[0].unsafeAddr, topics.len.csize_t)
 
-proc call*(ctx: HostContext, msg: evmc_message): evmc_result =
-  ctx.host.call(ctx.context, msg.unsafeAddr)
+proc call*(ctx: HostContext, msg: var evmc_message): evmc_result =
+  ctx.host.call(ctx.context, msg)
 
 proc init*(x: var EvmcVM, vm: ptr evmc_vm, hc: HostContext) =
   x.vm = vm
@@ -98,12 +98,12 @@ proc setOption*(vm: EvmcVM, name, value: string): evmc_set_option_result =
 
   result = EVMC_SET_OPTION_INVALID_NAME
 
-proc execute*(vm: EvmcVM, rev: evmc_revision, msg: evmc_message, code: openArray[byte]): evmc_result =
-  vm.vm.execute(vm.vm, vm.hc.host, vm.hc.context, rev, msg.unsafeAddr, code[0].unsafeAddr, code.len.csize_t)
+proc execute*(vm: EvmcVM, rev: evmc_revision, msg: var evmc_message, code: openArray[byte]): evmc_result =
+  vm.vm.execute(vm.vm, vm.hc.host, vm.hc.context, rev, msg, code[0].unsafeAddr, code.len.csize_t)
 
 proc destroy*(vm: EvmcVM) =
   vm.vm.destroy(vm.vm)
 
 proc destroy*(res: var evmc_result) =
   if not res.release.isNil:
-    res.release(res.unsafeAddr)
+    res.release(res)

--- a/tests/evmc_nim/nim_host.nim
+++ b/tests/evmc_nim/nim_host.nim
@@ -34,7 +34,7 @@ proc codeHash(acc: Account): evmc_bytes32 =
     let idx = v.int mod sizeof(result.bytes)
     result.bytes[idx] = result.bytes[idx] xor v
 
-proc evmcReleaseResultImpl(result: ptr evmc_result) {.cdecl.} =
+proc evmcReleaseResultImpl(result: var evmc_result) {.cdecl.} =
   discard
 
 proc evmcGetTxContextImpl(ctx: HostContext): evmc_tx_context {.cdecl.} =


### PR DESCRIPTION
Use `var` instead of `ptr` in the Nim EVMC API `import evmc/evmc` because all users of the API are already using `var`.

`var` is more convenient to work with, and API users use casts to ignore type mismatches.  Therefore, change the API itself to use `var`, so it's better to use directly, casts are not needed, and proper type checking can be used.

Another reason to do this is it brings Nim EVMC a step closer to the types actually used by API users, so eventually it won't be necessary to `cast[..]` function types, and proper type-checking can take place.

This is technically a breaking API change, but since the API users use casts to ignore type mismatches at the moment, it shouldn't break them.

Note: This is actually a stepping stone; we'll change to `{.byref.}` in a future patch, to represent `const type *` (read-only reference) which `var` does not.  This `var` version is useful for testing and in case we need to revert to it if there's a problem with `{.byref.}`.

Passing by reference (address) in Nim + C
-----------------------------------------

When translating a C binary interface to Nim, we can represent function arguments which are pointers in C as any of these in Nim:

- `ptr type`
- `var type`
- `type` assuming Nim's size heuristic picks pass by reference
- `type` with `{.byref.}` on the type definition

When passing by-reference, so far `ptr type` was used in Nim EVMC in `evmc.nim` in most places to define the API.  It was a more direct transalation of the C file, and `evmc_nim.nim` made extensive use of `unsafeAddr` to make calls from the VM side.

However, the example host in `nim_host.nim` defined its functions arguments with `var type`, so the functions didn't match the type signature defined in the API.  It worked because the function pointers were cast (so Nim did not check the types match), and because `ptr type` and `var type` are binary-compatible in Nim, even though they are not type-compatible.

Nimbus Eth1's EVMC support also defines functions with `var type` the same way as `nim_host.nim`, and even its interface file uses `var type`.

Since everything already relies on `var type` being a pointer argument "silently dereferenced" in Nim, switch the Nim EVMC API in `evmc.nim` to also use `var type`, to match the type signatures of implementation functions.

This is less clunky to use.  Implementations don't need to dereference pointers, and there's no need for `unsafeAddr` all over the place; these are removed from `evmc_nim.nim`.

Which types and arguments are changed
-------------------------------------

The following types are candidates for `var` as function arguments.  These are conceptually value types, which are passed by-const-reference for efficiency in the EVMC C `<evmc/evmc.h>` standardised binary interface.  Therefore we also pass them using `var` when they appear as an argument.  Values of these types are always returned by-value in the current binary interface:

- `evmc_address`
- `evmc_bytes32`
- `evmc_uint256be`
- `evmc_message`
- `evmc_result`
- `evmc_tx_context`

Not all these types appear in arguments currently, but if they did we would make them `var`.

`evmc_result` is special.  It has a destructor but is returned by copy.  This implies data which is safe to copy again, and implies the destructor doesn't care about the object address, only the contents.  Yet it is only safe to call the destructor on one of the copies, so this is not like an OOP destructor.

Things kept the same
--------------------

Variable size array arguments: `ptr byte` arrays and the `topics` array.

These arguments representing opaque handles are kept as `ptr`:

- `evmc_host_context` (`distinct pointer` is the type)
- `ptr evmc_vm`

These are opaque handles on one side of the EVMC host/VM divide.  They are kept as `ptr` to say on the opaque side, "be careful" and "don't mess with this".

Even though `evmc_vm` is a Nim `object`, it is the "base object" of a potentially larger object.  It must not be copied ("[object slicing] (https://en.wikipedia.org/wiki/Object_slicing)") and the original address must always be used.

When objects like these are passed as `var`, saving them requires conversion to `ptr` anyway with `unsafeAddr`.  Passing the saved value to another function requires dereferencing with `[]` even though we know the `[]` is cancelled by the receiving `var` and it's not really dereferenced.  None of that is helpful or clean; better to keep this sort of handle as `ptr`.

In regular Nim we would use `ref` for such types, but not with these because these are opaque pointers from C.  `ref` is only for values allocated by Nim.

- `ptr emvc_host_interface`

Perhaps surprisingly, this is plain old data, and can be safely copied even if it's part of a larger object.  Its address is not important either.  The reason for sticking with `ptr` is because the receiver normally stores the address without copying the contents, even though it would be safe to copy.  If it was `var` the receiver would use `unsafeAddr` to make a `ptr` anyway.