### PR TITLE
Update Nim API to follow EVMC API 8.0.0 (Berlin fork)

### DIFF
--- a/evmc/evmc_nim.nim
+++ b/evmc/evmc_nim.nim
@@ -67,6 +67,12 @@ proc selfdestruct*(ctx: HostContext, address, beneficiary: var evmc_address) =
 proc emitLog*(ctx: HostContext, address: var evmc_address, data: openArray[byte], topics: openArray[evmc_bytes32]) =
   ctx.host.emit_log(ctx.context, address, data[0].unsafeAddr, data.len.csize_t, topics[0].unsafeAddr, topics.len.csize_t)
 
+proc accessAccount*(ctx: HostContext, address: var evmc_address): evmc_access_status =
+  ctx.host.access_account(ctx.context, address)
+
+proc accessStorage*(ctx: HostContext, address: var evmc_address, key: var evmc_bytes32): evmc_access_status =
+  ctx.host.access_storage(ctx.context, address, key)
+
 proc call*(ctx: HostContext, msg: var evmc_message): evmc_result =
   ctx.host.call(ctx.context, msg)
 

--- a/tests/evmc_c/evmc.hpp
+++ b/tests/evmc_c/evmc.hpp
@@ -465,6 +465,12 @@ public:
                           size_t data_size,
                           const bytes32 topics[],
                           size_t num_topics) noexcept = 0;
+
+    /// @copydoc evmc_host_interface::access_account
+    virtual evmc_access_status access_account(const address& addr) noexcept = 0;
+
+    /// @copydoc evmc_host_interface::access_storage
+    virtual evmc_access_status access_storage(const address& addr, const bytes32& key) noexcept = 0;
 };
 
 
@@ -563,6 +569,16 @@ public:
                   size_t topics_count) noexcept final
     {
         host->emit_log(context, &addr, data, data_size, topics, topics_count);
+    }
+
+    evmc_access_status access_account(const address& address) noexcept final
+    {
+        return host->access_account(context, &address);
+    }
+
+    evmc_access_status access_storage(const address& address, const bytes32& key) noexcept final
+    {
+        return host->access_storage(context, &address, &key);
     }
 };
 
@@ -805,6 +821,18 @@ inline void emit_log(evmc_host_context* h,
     Host::from_context(h)->emit_log(*addr, data, data_size, static_cast<const bytes32*>(topics),
                                     num_topics);
 }
+
+inline evmc_access_status access_account(evmc_host_context* h, const evmc_address* addr) noexcept
+{
+    return Host::from_context(h)->access_account(*addr);
+}
+
+inline evmc_access_status access_storage(evmc_host_context* h,
+                                         const evmc_address* addr,
+                                         const evmc_bytes32* key) noexcept
+{
+    return Host::from_context(h)->access_storage(*addr, *key);
+}
 }  // namespace internal
 
 inline const evmc_host_interface& Host::get_interface() noexcept
@@ -815,7 +843,9 @@ inline const evmc_host_interface& Host::get_interface() noexcept
         ::evmc::internal::get_code_size,  ::evmc::internal::get_code_hash,
         ::evmc::internal::copy_code,      ::evmc::internal::selfdestruct,
         ::evmc::internal::call,           ::evmc::internal::get_tx_context,
-        ::evmc::internal::get_block_hash, ::evmc::internal::emit_log};
+        ::evmc::internal::get_block_hash, ::evmc::internal::emit_log,
+        ::evmc::internal::access_account, ::evmc::internal::access_storage,
+    };
     return interface;
 }
 }  // namespace evmc

--- a/tests/evmc_c/example_host.cpp
+++ b/tests/evmc_c/example_host.cpp
@@ -163,6 +163,20 @@ public:
         (void)topics;
         (void)topics_count;
     }
+
+    evmc_access_status access_account(const evmc::address& addr) noexcept final
+    {
+        (void)addr;
+        return EVMC_ACCESS_COLD;
+    }
+
+    evmc_access_status access_storage(const evmc::address& addr,
+                                      const evmc::bytes32& key) noexcept final
+    {
+        (void)addr;
+        (void)key;
+        return EVMC_ACCESS_COLD;
+    }
 };
 
 

--- a/tests/evmc_c/instructions.h
+++ b/tests/evmc_c/instructions.h
@@ -53,7 +53,7 @@ enum evmc_opcode
     OP_SHR = 0x1c,
     OP_SAR = 0x1d,
 
-    OP_SHA3 = 0x20,
+    OP_KECCAK256 = 0x20,
 
     OP_ADDRESS = 0x30,
     OP_BALANCE = 0x31,

--- a/tests/evmc_nim/nim_host.nim
+++ b/tests/evmc_nim/nim_host.nim
@@ -103,6 +103,14 @@ proc evmcEmitLogImpl(ctx: HostContext, address: var evmc_address,
                            topics: ptr evmc_bytes32, topics_count: csize_t) {.cdecl.} =
   discard
 
+proc evmcAccessAccountImpl(ctx: HostContext,
+                           address: var evmc_address): evmc_access_status {.cdecl.} =
+  return EVMC_ACCESS_COLD
+
+proc evmcAccessStorageImpl(ctx: HostContext, address: var evmc_address,
+                           key: var evmc_bytes32): evmc_access_status {.cdecl.} =
+  return EVMC_ACCESS_WARM
+
 proc evmcCallImpl(ctx: HostContext, msg: var evmc_message): evmc_result {.cdecl.} =
   result = evmc_result(status_code: EVMC_REVERT, gas_left: msg.gas, output_data: msg.input_data, output_size: msg.input_size)
 
@@ -171,6 +179,8 @@ proc init_host_interface(): evmc_host_interface =
   result.get_tx_context = CAST[evmc_get_tx_context_fn](evmcGetTxContextImpl)
   result.get_block_hash = CAST[evmc_get_block_hash_fn](evmcGetBlockHashImpl)
   result.emit_log = CAST[evmc_emit_log_fn](evmcEmitLogImpl)
+  result.access_account = CAST[evmc_access_account_fn](evmcAccessAccountImpl)
+  result.access_storage = CAST[evmc_access_storage_fn](evmcAccessStorageImpl)
 
 const
   EVMC_HOST_NAME = "example_vm"

--- a/tests/test_host_vm.nim
+++ b/tests/test_host_vm.nim
@@ -158,6 +158,19 @@ template runTest(testName: string, create_vm, get_host_interface, create_host_co
     test "emitlog":
       hc.emitLog(address, code, [ahash])
 
+    test "accessAccount":
+      let state = hc.accessAccount(address)
+      check state == EVMC_ACCESS_COLD
+
+    test "accessStorage":
+      let state = hc.accessStorage(address, key)
+      if create_vm == evmc_create_example_vm:
+        # The C++ fake VM returns COLD (0) and we won't change that.
+        check state == EVMC_ACCESS_COLD
+      else:
+        # The Nim fake VM returns WARM (1) just to verify a non-trivial value gets through.
+        check state == EVMC_ACCESS_WARM
+
     test "call":
       let res = hc.call(msg)
       check res.status_code == EVMC_REVERT


### PR DESCRIPTION
The changes from API version 7.5.0 to 8.0.0 are Berlin fork (EIP-2929) support:

- EIP-2929 support
- `access_account` host service.
- `access_storage` host service.
- `access_status` type with values `EVMC_ACCESS_COLD` and `EVMC_ACCESS_WARM`.
- `EVMC_ABI_VERSION` is updated to 8, because this change is not backward compatible

It's not backward compatible because a version 8 EVM will crash if called from a version 7 host.  However, a host supporting version 8 EVM can safely call a version 7 EVM and it will work, there just won't be EIP-2929 functionality.
Precompile-only EVMs behave identically between version 7 and 8.