### PR TITLE
Nim: Export `evmc_create_vm_name_fn`

### DIFF
--- a/evmc/evmc.nim
+++ b/evmc/evmc.nim
@@ -739,7 +739,7 @@ type
   # "beta-interpreter" implementation may be named libbeta-interpreter.so.
   #
   # @return  The VM instance or NULL indicating instance creation failure.
-  evmc_create_vm_name_fn = proc(): ptr evmc_vm {.cdecl.}
+  evmc_create_vm_name_fn* = proc(): ptr evmc_vm {.cdecl.}
 
 const
   # The maximum EVM revision supported.


### PR DESCRIPTION
This type proved useful in applications, so export it.