### PR TITLE
emvc revision from 8.0.0 to 9.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ kinds of calls are in this API.
 
 ## Current status
 
+__2021-06-27__
+- Supports EVMC API version 9.0.0.  This API is suitable for transactions up to
+and including Ethereum *London*.
+
 __2021-05-08__
 - Supports EVMC API version 8.0.0.  This API is suitable for transactions up to
 and including Ethereum *Berlin*, the current version on mainnet at the time of

--- a/evmc/evmc.nim
+++ b/evmc/evmc.nim
@@ -13,7 +13,7 @@
 # The EVMC ABI version always equals the major version number of the EVMC project.
 # The Host SHOULD check if the ABI versions match when dynamically loading VMs.
 const
-  EVMC_ABI_VERSION* = 8.cint
+  EVMC_ABI_VERSION* = 9.cint
 
 # EVMC adopts the C99 standard, and one of its interfaces uses C99 `bool`.
 #
@@ -124,6 +124,7 @@ type
     block_gas_limit* : int64          # The block gas limit.
     block_difficulty*: evmc_uint256be # The block difficulty.
     chain_id*        : evmc_uint256be # The blockchain's ChainID.
+    block_base_fee*  : evmc_uint256be # The block base fee.
 
   # @struct evmc_host_context
   # The opaque data type representing the Host execution context.
@@ -627,6 +628,10 @@ type
     # The Berlin revision.
     # The spec draft: https://eips.ethereum.org/EIPS/eip-2070.
     EVMC_BERLIN = 8
+
+    # The London revision.
+    # The spec draft: https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/mainnet-upgrades/london.md
+    EVMC_LONDON = 9
 
   # Executes the given code using the input from the message.
   #

--- a/tests/evmc_c/evmc.h
+++ b/tests/evmc_c/evmc.h
@@ -44,7 +44,7 @@ enum
      *
      * @see @ref versioning
      */
-    EVMC_ABI_VERSION = 8
+    EVMC_ABI_VERSION = 9
 };
 
 
@@ -154,6 +154,7 @@ struct evmc_tx_context
     int64_t block_gas_limit;         /**< The block gas limit. */
     evmc_uint256be block_difficulty; /**< The block difficulty. */
     evmc_uint256be chain_id;         /**< The blockchain's ChainID. */
+    evmc_uint256be block_base_fee;   /**< The block base fee. */
 };
 
 /**


### PR DESCRIPTION
- add block_base_fee field to tx_context, this additional field came from EIP-1559
- bump EVMC_API_VERSION to 9
- add EVMC_LONDON to evmc_revision