### PR TITLE
Add bool return to evmc_selfdestruct_fn function type as defined in EVMC spec

### DIFF
--- a/evmc/evmc.nim
+++ b/evmc/evmc.nim
@@ -597,7 +597,9 @@ type
   # @param context      The pointer to the Host execution context. See ::evmc_host_context.
   # @param address      The address of the contract to be selfdestructed.
   # @param beneficiary  The address where the remaining ETH is going to be transferred.
-  evmc_selfdestruct_fn* = proc(context: evmc_host_context, address, beneficiary: var evmc_address) {.evmc_abi.}
+  # @return             The information if the given address has not been registered as
+  #                     selfdestructed yet. True if registered for the first time, false otherwise.
+  evmc_selfdestruct_fn* = proc(context: evmc_host_context, address, beneficiary: var evmc_address): c99bool {.evmc_abi.}
 
   # Log callback function.
   #

--- a/evmc/evmc_nim.nim
+++ b/evmc/evmc_nim.nim
@@ -61,8 +61,8 @@ proc copyCode*(ctx: HostContext, address: var evmc_address, codeOffset: int = 0)
 proc copyCode*(ctx: HostContext, address: var evmc_address, codeOffset: int, output: ptr byte, output_len: int): int =
   ctx.host.copy_code(ctx.context, address, codeOffset.csize_t, output, output_len.csize_t).int
 
-proc selfdestruct*(ctx: HostContext, address, beneficiary: var evmc_address) =
-  ctx.host.selfdestruct(ctx.context, address, beneficiary)
+proc selfdestruct*(ctx: HostContext, address, beneficiary: var evmc_address): bool =
+  ctx.host.selfdestruct(ctx.context, address, beneficiary).bool
 
 proc emitLog*(ctx: HostContext, address: var evmc_address, data: openArray[byte], topics: openArray[evmc_bytes32]) =
   ctx.host.emit_log(ctx.context, address, data[0].unsafeAddr, data.len.csize_t, topics[0].unsafeAddr, topics.len.csize_t)

--- a/tests/evmc_nim/nim_host.nim
+++ b/tests/evmc_nim/nim_host.nim
@@ -104,8 +104,9 @@ proc evmcCopyCodeImpl(p: evmc_host_context, address: var evmc_address,
       copyMem(buffer_data, acc[].code[code_offset].addr, n)
     result = n.csize_t
 
-proc evmcSelfdestructImpl(p: evmc_host_context, address, beneficiary: var evmc_address) {.cdecl.} =
+proc evmcSelfdestructImpl(p: evmc_host_context, address, beneficiary: var evmc_address): c99bool {.cdecl.} =
   discard evmcHostContext(p)
+  true
 
 proc evmcEmitLogImpl(p: evmc_host_context, address: var evmc_address,
                            data: ptr byte, data_size: csize_t,

--- a/tests/test_host_vm.nim
+++ b/tests/test_host_vm.nim
@@ -157,7 +157,7 @@ template runTest(testName: string, create_vm, get_host_interface, create_host_co
       check acode == bcode
 
     test "selfdestruct":
-      hc.selfdestruct(address, address)
+      check hc.selfdestruct(address, address) == true
 
     test "emitlog":
       hc.emitLog(address, code, [ahash])


### PR DESCRIPTION
The EVMC c definition of the `evmc_selfdestruct_fn` function type has a `bool` return type but our nim definition of the same function was missing the `bool` return. This PR fixes the issue by adding in the bool to make our nim implementation align with the EVMC spec.